### PR TITLE
XMDEV-57: Updates shipments views to show truck display name

### DIFF
--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -4,4 +4,8 @@ class Truck < ApplicationRecord
     validates :make, :model, presence: true
     validates :year, numericality: { only_integer: true, greater_than_or_equal_to: 1900 }
     validates :mileage, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+    def display_name
+        "#{make}-#{model}-#{year}"
+      end
 end

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -52,8 +52,8 @@
   </div>
 
   <div class="form-group">
-    <%= form.label :truck_id, class: 'form-label' %>
-    <%= form.number_field :truck_id, class: 'form-input' %>
+    <%= form.label :truck_id, 'Truck', class: 'form-label' %>
+    <%= form.collection_select :truck_id, Truck.all, :id, :display_name, { prompt: "Please select a truck" }, { class: 'form-input' } %>
   </div>
 
   <div class="form-actions">

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -13,7 +13,7 @@
   <p><strong>Weight:</strong> <span class="detail-value"><%= @shipment.weight %> kg</span></p>
   <p><strong>Boxes:</strong> <span class="detail-value"><%= @shipment.boxes %></span></p>
   <% if @shipment.truck %>
-    <p><strong>Truck:</strong> <span class="detail-value"><%= link_to @shipment.truck.make, @shipment.truck %></span></p>
+    <p><strong>Truck:</strong> <span class="detail-value"><%= link_to @shipment.truck.display_name, @shipment.truck %></span></p>
   <% end %>
 </div>
 

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -78,4 +78,18 @@ RSpec.describe Truck, type: :model do
       expect(valid_truck).not_to be_valid
     end
   end
+
+  ## Custom Method Tests
+  describe "#display_name" do
+    it "returns a string formatted as make-model-year" do
+      expect(valid_truck.display_name).to eq("Volvo-VNL-2021")
+    end
+
+    it "handles nil values gracefully" do
+      valid_truck.make = nil
+      valid_truck.model = nil
+      valid_truck.year = nil
+      expect(valid_truck.display_name).to eq("--")
+    end
+  end
 end


### PR DESCRIPTION
## Description
Updates the shipment views to show the truck display name

## Approach Taken
Good ol' rails.

## What Could Go Wrong?
Nothing. Purely cosmetic. I confirm graceful error handling if no trucks exist.

## Remediation Stategy 
N/A
