### PR TITLE
XMDEV-24: Account owner can create other drivers

### DIFF
--- a/app/controllers/driver_managements_controller.rb
+++ b/app/controllers/driver_managements_controller.rb
@@ -1,11 +1,11 @@
 class DriverManagementsController < ApplicationController
     before_action :authenticate_user!
     before_action :ensure_admin
-  
+
     def new
       @driver = User.new(role: "driver")
     end
-  
+
     def create
       @driver = User.new(driver_params)
       @driver.role = "driver"
@@ -15,19 +15,18 @@ class DriverManagementsController < ApplicationController
         render :new, alert: "Unable to create driver account."
       end
     end
-  
+
     def index
       @drivers = User.drivers
     end
-  
+
     private
-  
+
     def driver_params
       params.require(:user).permit(:first_name, :last_name, :drivers_license, :email, :password, :password_confirmation)
     end
-  
+
     def ensure_admin
       redirect_to(root_path, alert: "Not authorized.") unless current_user&.admin?
     end
-  end
-  
+end

--- a/app/controllers/driver_managements_controller.rb
+++ b/app/controllers/driver_managements_controller.rb
@@ -1,0 +1,33 @@
+class DriverManagementsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :ensure_admin
+  
+    def new
+      @driver = User.new(role: "driver")
+    end
+  
+    def create
+      @driver = User.new(driver_params)
+      @driver.role = "driver"
+      if @driver.save
+        redirect_to driver_managements_path, notice: "Driver account created successfully."
+      else
+        render :new, alert: "Unable to create driver account."
+      end
+    end
+  
+    def index
+      @drivers = User.drivers
+    end
+  
+    private
+  
+    def driver_params
+      params.require(:user).permit(:first_name, :last_name, :drivers_license, :email, :password, :password_confirmation)
+    end
+  
+    def ensure_admin
+      redirect_to(root_path, alert: "Not authorized.") unless current_user&.admin?
+    end
+  end
+  

--- a/app/helpers/driver_management_helper.rb
+++ b/app/helpers/driver_management_helper.rb
@@ -1,0 +1,2 @@
+module DriverManagementHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,9 @@ class User < ApplicationRecord
 
   enum :role, { driver: 0, admin: 1 }
 
+  scope :drivers, -> { where(role: "driver") }
+  scope :admins, -> { where(role: "admin") }
+
   # Convenience methods
   def admin?
     role == "admin"

--- a/app/views/driver_managements/index.html.erb
+++ b/app/views/driver_managements/index.html.erb
@@ -1,0 +1,20 @@
+<h1>Drivers</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Email</th>
+      <th>Created At</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @drivers.each do |driver| %>
+      <tr>
+        <td><%= driver.email %></td>
+        <td><%= driver.created_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to "Create New Driver", new_driver_management_path, class: "btn btn-primary" %>

--- a/app/views/driver_managements/new.html.erb
+++ b/app/views/driver_managements/new.html.erb
@@ -1,0 +1,48 @@
+<h1>Create New Driver</h1>
+
+<%= form_with model: @driver, url: driver_managements_path, local: true do |f| %>
+  <% if @driver.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@driver.errors.count, "error") %> prohibited this driver from being saved:</h2>
+      <ul>
+        <% @driver.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :first_name, "First Name"%>
+    <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :last_name, "Last Name", class: 'form-label' %>
+    <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :drivers_license, "Driver's License" %>
+    <%= f.text_field :drivers_license %>
+  </div>
+
+  <div class="field">
+    <%= f.label :email %>
+    <%= f.email_field :email, required: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <%= f.password_field :password, required: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, required: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Create Driver" %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,12 +24,22 @@
     <header>
       <nav class="navbar">
         <div class="navbar-title">TRUCKIN' ALONG</div>
-        <div class="navbar-links">
-          <%= link_to 'Statuses', shipment_statuses_path, class: 'nav-link' %>
-        </div>
+        <% if user_signed_in? && current_user.admin? %>
+          <div class="navbar-links">
+            <%= link_to 'User Management', driver_managements_path, class: 'nav-link' %>
+          </div>
+        
+          <div class="navbar-links">
+            <%= link_to 'Statuses', shipment_statuses_path, class: 'nav-link' %>
+          </div>
+        <% end %>
         <div class="navbar-links">
           <%= link_to 'Shipments', shipments_path, class: 'nav-link' %>
         </div>
+        <div class="navbar-links">
+          <%= link_to 'Truck Management', trucks_path, class: 'nav-link' %>
+        </div>
+
         <div class="navbar-links">
           <%= link_to 'Truck Management', trucks_path, class: 'nav-link' %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :shipment_statuses
   resources :shipments
   resources :trucks
+  resources :driver_managements, only: [:new, :create, :index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :shipment_statuses
   resources :shipments
   resources :trucks
-  resources :driver_managements, only: [:new, :create, :index]
+  resources :driver_managements, only: [ :new, :create, :index ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/controllers/driver_managements_controller_spec.rb
+++ b/spec/controllers/driver_managements_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DriverManagementsController, type: :controller do
     context 'as an admin' do
       it 'assigns all drivers to @drivers and renders the index template' do
         get :index
-        expect(assigns(:drivers)).to eq([driver])
+        expect(assigns(:drivers)).to eq([ driver ])
         expect(response).to render_template(:index)
       end
     end

--- a/spec/controllers/driver_managements_controller_spec.rb
+++ b/spec/controllers/driver_managements_controller_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe DriverManagementsController, type: :controller do
+  let(:admin_user) { User.create!(email: "admin@example.com", password: "password", role: "admin") }
+  let(:non_admin_user) { User.create!(email: "user@example.com", password: "password", role: "driver") }
+
+  let!(:driver) { User.create!(first_name: "John", last_name: "Doe", drivers_license: "12345", email: "driver@example.com", password: "password", role: "driver") }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe 'GET #index' do
+    context 'as an admin' do
+      it 'assigns all drivers to @drivers and renders the index template' do
+        get :index
+        expect(assigns(:drivers)).to eq([driver])
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'as a non-admin' do
+      it 'redirects to the root path with an alert' do
+        sign_out admin_user
+        sign_in non_admin_user
+
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("Not authorized.")
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    it 'assigns a new driver to @driver and renders the new template' do
+      get :new
+      expect(assigns(:driver)).to be_a_new(User)
+      expect(assigns(:driver).role).to eq("driver")
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid attributes' do
+      it 'creates a new driver and redirects to the index page' do
+        expect {
+          post :create, params: {
+            user: {
+              first_name: "Jane",
+              last_name: "Smith",
+              drivers_license: "54321",
+              email: "jane@example.com",
+              password: "password",
+              password_confirmation: "password"
+            }
+          }
+        }.to change(User.drivers, :count).by(1)
+
+        expect(response).to redirect_to(driver_managements_path)
+        expect(flash[:notice]).to eq("Driver account created successfully.")
+      end
+    end
+  end
+
+  describe 'Authorization' do
+    it 'redirects non-admin users attempting to access #new' do
+      sign_out admin_user
+      sign_in non_admin_user
+
+      get :new
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("Not authorized.")
+    end
+
+    it 'redirects non-admin users attempting to create a driver' do
+      sign_out admin_user
+      sign_in non_admin_user
+
+      post :create, params: {
+        user: {
+          first_name: "Jane",
+          last_name: "Smith",
+          drivers_license: "54321",
+          email: "jane@example.com",
+          password: "password",
+          password_confirmation: "password"
+        }
+      }
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("Not authorized.")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe User, type: :model do
   describe "scopes" do
     let!(:driver_user) { User.create!(email: "driver@example.com", password: "password", role: :driver) }
     let!(:admin_user) { User.create!(email: "admin@example.com", password: "password", role: :admin) }
-  
+
     describe ".drivers" do
       it "includes only users with the driver role" do
         expect(User.drivers).to include(driver_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,6 +71,26 @@ RSpec.describe User, type: :model do
     end
   end
 
+  ## Scope Tests
+  describe "scopes" do
+    let!(:driver_user) { User.create!(email: "driver@example.com", password: "password", role: :driver) }
+    let!(:admin_user) { User.create!(email: "admin@example.com", password: "password", role: :admin) }
+  
+    describe ".drivers" do
+      it "includes only users with the driver role" do
+        expect(User.drivers).to include(driver_user)
+        expect(User.drivers).not_to include(admin_user)
+      end
+    end
+
+    describe ".admins" do
+      it "includes only users with the admin role" do
+        expect(User.admins).to include(admin_user)
+        expect(User.admins).not_to include(driver_user)
+      end
+    end
+  end
+
   ## Custom Method Tests
   describe "#admin?" do
     it "returns true if the user's role is admin" do

--- a/spec/requests/driver_management_spec.rb
+++ b/spec/requests/driver_management_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe DriverManagementsController, type: :request do
+  let(:admin_user) { User.create!(email: "admin@example.com", password: "password", role: "admin") }
+  let(:driver_user) { User.create!(email: "driver@example.com", password: "password", role: "driver") }
+
+  let(:valid_attributes) {
+    { first_name: "John", last_name: "Doe", drivers_license: "A123456", email: "newdriver@example.com", password: "password", password_confirmation: "password" }
+  }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_driver_management_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      it "creates a new driver" do
+        expect {
+          post driver_managements_url, params: { user: valid_attributes }
+        }.to change(User, :count).by(1)
+      end
+
+      it "redirects to the driver managements index page with a success notice" do
+        post driver_managements_url, params: { user: valid_attributes }
+        expect(response).to redirect_to(driver_managements_url)
+        expect(flash[:notice]).to eq("Driver account created successfully.")
+      end
+    end
+  end
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      get driver_managements_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "Unauthorized Access" do
+    context "when the user is not an admin" do
+      before do
+        sign_in driver_user
+      end
+
+      it "redirects to the root path with an alert" do
+        get driver_managements_url
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("Not authorized.")
+      end
+    end
+  end
+end

--- a/spec/routing/driver_managements_routing_spec.rb
+++ b/spec/routing/driver_managements_routing_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe DriverManagementsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/driver_managements").to route_to("driver_managements#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/driver_managements/new").to route_to("driver_managements#new")
+    end
+
+    it "routes to #create" do
+      expect(post: "/driver_managements").to route_to("driver_managements#create")
+    end
+  end
+end


### PR DESCRIPTION
## Description
Allows account owners to create drivers.

## Approach Taken
Standard rails stuff. Created the controller, augmented the user model, scoped things to admin users only.

## What Could Go Wrong?
Nothing. All supporting infra is present.

## Remediation Stategy 
N/A
