### PR TITLE
XMDEV-85: Fix CSS rules to show highlights on danger button and proper button widths

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,7 +28,6 @@ button, .primary-button, .secondary-button, .danger-button {
 }
 
 .primary-button {
-  width: 100%; /* Full width for better CTA visibility */
   background-color: #09e80d;
   color: #fff;
   border: none;
@@ -211,6 +210,15 @@ button, .primary-button, .secondary-button, .danger-button {
   display: inline-block;
   margin-bottom: 0.5rem;
   font-size: 1rem;
+}
+
+.action-link.danger-link {
+  color: #dc3545; /* Red for destructive actions */
+}
+
+.action-link.danger-link:hover {
+  color: #c82333; /* Darker red on hover */
+  text-decoration: underline;
 }
 
 .auth-links .danger-link {


### PR DESCRIPTION
## Description
Some CSS rule bugs were causing some incorrect highlighting and button widths.

## Approach Taken
Found the CSS rule issue, and corrected it accordingly.

## What Could Go Wrong?
Nothing. Purely a cosmetic change.

## Remediation Strategy 
N/A
