### PR TITLE
XMDEV-113: Handles recordNotFound errors gracefully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,30 +5,36 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :redirect_unless_company_registered
 
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
+
   def current_company
     current_user&.company
   end
 
   private
 
-  def redirect_unless_company_registered
-    return if user_signed_in? && current_user.customer?
-    return if devise_controller? || controller_name.in?(%w[companies welcome])
+    def redirect_unless_company_registered
+      return if user_signed_in? && current_user.customer?
+      return if devise_controller? || controller_name.in?(%w[companies welcome])
 
-    if user_signed_in? && !current_user.has_company?
-      flash[:alert] = "You must register a company before accessing the application."
-      redirect_to new_company_path
+      if user_signed_in? && !current_user.has_company?
+        flash[:alert] = "You must register a company before accessing the application."
+        redirect_to new_company_path
+      end
     end
-  end
 
-  def ensure_admin
-    redirect_to(root_path, alert: "Not authorized.") unless current_user&.admin?
-  end
+    def ensure_admin
+      redirect_to(root_path, alert: "Not authorized.") unless current_user&.admin?
+    end
+
+    def handle_record_not_found
+      redirect_to(root_path, alert: "Not authorized.")
+    end
 
   protected
 
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :first_name, :last_name, :drivers_license, :role, :home_address ])
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :first_name, :last_name, :drivers_license, :role, :home_address ])
-  end
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [ :first_name, :last_name, :drivers_license, :role, :home_address ])
+      devise_parameter_sanitizer.permit(:account_update, keys: [ :first_name, :last_name, :drivers_license, :role, :home_address ])
+    end
 end

--- a/spec/controllers/driver_managements_controller_spec.rb
+++ b/spec/controllers/driver_managements_controller_spec.rb
@@ -88,15 +88,21 @@ RSpec.describe DriverManagementsController, type: :controller do
         expect(response).to render_template(:edit)
       end
 
-      it "raises ActiveRecord::RecordNotFound for a driver from another company" do
-        expect {
-          get :edit, params: { id: other_non_admin_user.id }
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-
       it "responds successfully" do
         get :edit, params: { id: non_admin_user.id }
         expect(response).to have_http_status(:ok)
+      end
+
+      context "when the driver is from another company" do
+        it 'redirects to the root path' do
+          get :edit, params: { id: other_non_admin_user.id }
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders with an alert' do
+          get :edit, params: { id: other_non_admin_user.id }
+          expect(flash[:alert]).to eq("Not authorized.")
+        end
       end
     end
 

--- a/spec/controllers/shipment_status_controller_spec.rb
+++ b/spec/controllers/shipment_status_controller_spec.rb
@@ -54,15 +54,21 @@ RSpec.describe ShipmentStatusesController, type: :controller do
         expect(response).to render_template(:edit)
       end
 
-      it "raises ActiveRecord::RecordNotFound for a shipment_statuses from another company" do
-        expect {
-          get :edit, params: { id: other_shipment_status.id }
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-
       it "responds successfully" do
         get :edit, params: { id: shipment_status.id }
         expect(response).to have_http_status(:ok)
+      end
+
+      context "when the shipment status belongs to another company" do
+        it 'redirects to the root path' do
+          get :edit, params: { id: other_shipment_status.id }
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders with an alert' do
+          get :edit, params: { id: other_shipment_status.id }
+          expect(flash[:alert]).to eq("Not authorized.")
+        end
       end
     end
 
@@ -149,10 +155,16 @@ RSpec.describe ShipmentStatusesController, type: :controller do
         expect(response).to redirect_to(admin_index_path)
       end
 
-      it "raises ActiveRecord::RecordNotFound for a shipment_status from another company" do
-        expect {
+      context "when the shipment status belongs to another company" do
+        it 'redirects to the root path' do
           delete :destroy, params: { id: other_shipment_status.id }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders with an alert' do
+          delete :destroy, params: { id: other_shipment_status.id }
+          expect(flash[:alert]).to eq("Not authorized.")
+        end
       end
     end
   end

--- a/spec/controllers/truck_controller_spec.rb
+++ b/spec/controllers/truck_controller_spec.rb
@@ -51,10 +51,16 @@ RSpec.describe TrucksController, type: :controller do
         expect(response).to have_http_status(:ok)
       end
 
-      it "raises ActiveRecord::RecordNotFound for a truck from another company" do
-        expect {
+      context "when the truck belongs to another company" do
+        it 'redirects to the root path' do
           get :show, params: { id: other_truck.id }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders with an alert' do
+          get :show, params: { id: other_truck.id }
+          expect(flash[:alert]).to eq("Not authorized.")
+        end
       end
     end
 
@@ -86,15 +92,21 @@ RSpec.describe TrucksController, type: :controller do
         expect(response).to render_template(:edit)
       end
 
-      it "raises ActiveRecord::RecordNotFound for a truck from another company" do
-        expect {
-          get :edit, params: { id: other_truck.id }
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-
       it "responds successfully" do
         get :edit, params: { id: truck.id }
         expect(response).to have_http_status(:ok)
+      end
+
+      context "when the truck belongs to another company" do
+        it 'redirects to the root path' do
+          get :edit, params: { id: other_truck.id }
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders with an alert' do
+          get :edit, params: { id: other_truck.id }
+          expect(flash[:alert]).to eq("Not authorized.")
+        end
       end
     end
 
@@ -185,10 +197,16 @@ RSpec.describe TrucksController, type: :controller do
         expect(response).to redirect_to(admin_index_path)
       end
 
-      it "raises ActiveRecord::RecordNotFound for a truck from another company" do
-        expect {
+      context "when the truck belongs to another company" do
+        it 'redirects to the root path' do
           delete :destroy, params: { id: other_truck.id }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders with an alert' do
+          delete :destroy, params: { id: other_truck.id }
+          expect(flash[:alert]).to eq("Not authorized.")
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
RecordNotFound errors were hard failures which were manifesting as non recoverable errors.

## Approach Taken
We were exposing hard failures when a record was not found. Now the app will direct the user to the root page in the event of a RecordNotFound error.

## What Could Go Wrong?
This fixes a bug. It fixes functionality that was previously not working.

## Remediation Strategy 
NA
