### PR TITLE
XMDEV-119: Adds VIN and license plate to truck model (breaking)

### DIFF
--- a/app/controllers/trucks_controller.rb
+++ b/app/controllers/trucks_controller.rb
@@ -50,6 +50,6 @@ class TrucksController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def truck_params
-      params.expect(truck: [ :make, :model, :year, :mileage, :weight, :length, :width, :height, :company_id ])
+      params.expect(truck: [ :make, :model, :year, :vin, :license_plate, :mileage, :weight, :length, :width, :height, :company_id ])
     end
 end

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -8,9 +8,12 @@ class Truck < ApplicationRecord
   validates :year, numericality: { only_integer: true, greater_than_or_equal_to: 1900 }
   validates :mileage, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  validates :vin, presence: true, uniqueness: true, length: { is: 17 }
+  validates :license_plate, presence: true
+
   scope :for_company, ->(company) { where(company_id: company.id) }
 
   def display_name
-    "#{make}-#{model}-#{year}"
+    "#{make}-#{model}-#{year}(#{license_plate})"
   end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -70,6 +70,7 @@
       <th>Model</th>
       <th>Year</th>
       <th>Mileage</th>
+      <th>License Plate</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -80,6 +81,7 @@
         <td><%= truck.model %></td>
         <td><%= truck.year %></td>
         <td><%= truck.mileage %></td>
+        <td><%= truck.license_plate %></td>
         <td>
           <%= link_to 'Show', truck, class: 'action-link' %> |
           <%= link_to 'Edit', edit_truck_path(truck), class: 'action-link' %> |

--- a/app/views/trucks/_form.html.erb
+++ b/app/views/trucks/_form.html.erb
@@ -33,6 +33,16 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :vin, class: 'form-label' %>
+    <%= form.text_field :vin, class: 'form-input' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :license_plate, class: 'form-label' %>
+    <%= form.text_field :license_plate, class: 'form-input' %>
+  </div>
+
+  <div class="form-group">
     <%= form.label :weight, class: 'form-label' %>
     <%= form.text_field :weight, class: 'form-input' %>
   </div>

--- a/app/views/trucks/show.html.erb
+++ b/app/views/trucks/show.html.erb
@@ -8,6 +8,8 @@
   <p><strong>Model:</strong> <span class="detail-value"><%= @truck.model %></span></p>
   <p><strong>Year:</strong> <span class="detail-value"><%= @truck.year %></span></p>
   <p><strong>Mileage:</strong> <span class="detail-value"><%= @truck.mileage %> miles</span></p>
+  <p><strong>VIN:</strong> <span class="detail-value"><%= @truck.vin %></span></p>
+  <p><strong>License Plate:</strong> <span class="detail-value"><%= @truck.license_plate %></span></p>
 </div>
 
 <div class="details-actions">

--- a/db/migrate/20250203045135_add_vin_and_license_plate_to_trucks.rb
+++ b/db/migrate/20250203045135_add_vin_and_license_plate_to_trucks.rb
@@ -1,0 +1,11 @@
+class AddVinAndLicensePlateToTrucks < ActiveRecord::Migration[8.0]
+  def change
+    unless column_exists?(:trucks, :vin)
+      add_column :trucks, :vin, :string, null: false
+    end
+
+    unless column_exists?(:trucks, :license_plate)
+      add_column :trucks, :license_plate, :string, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_01_163757) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_03_045135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -64,6 +64,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_163757) do
     t.decimal "width"
     t.decimal "height"
     t.decimal "weight"
+    t.string "vin", null: false
+    t.string "license_plate", null: false
     t.index ["company_id"], name: "index_trucks_on_company_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,7 +92,9 @@ truck1 = Truck.create!(
   weight: 18000, # in kilograms
   length: 1000.5,
   height: 300.9,
-  width: 200.5
+  width: 200.5,
+  vin: "1HGCM82633A004352",
+  license_plate: "ABC-1234"
 )
 
 truck2 = Truck.create!(
@@ -104,7 +106,9 @@ truck2 = Truck.create!(
   weight: 19000, # in kilograms
   length: 1100.0,
   height: 400.0,
-  width: 200.5
+  width: 200.5,
+  vin: "2C3KA53G76H123456",
+  license_plate: "XYZ-9876"
 )
 
 truck3 = Truck.create!(
@@ -116,7 +120,9 @@ truck3 = Truck.create!(
   weight: 18500, # in kilograms
   length: 1000.8,
   height: 300.8,
-  width: 200.5
+  width: 200.5,
+  vin: "5N1AR18B98C765432",
+  license_plate: "LMN-4567"
 )
 
 truck4 = Truck.create!(
@@ -128,7 +134,9 @@ truck4 = Truck.create!(
   weight: 18700, # in kilograms
   length: 1000.6,
   height: 300.9,
-  width: 200.5
+  width: 200.5,
+  vin: "JH4KA9650MC012345",
+  license_plate: "QWE-8523"
 )
 
 truck5 = Truck.create!(
@@ -140,7 +148,9 @@ truck5 = Truck.create!(
   weight: 18300, # in kilograms
   length: 1100.2,
   height: 300.95,
-  width: 200.5
+  width: 200.5,
+  vin: "WDBRF61J43F234567",
+  license_plate: "JKL-3698"
 )
 
 

--- a/spec/factories/trucks.rb
+++ b/spec/factories/trucks.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     length { Faker::Number.decimal(l_digits: 3, r_digits: 1) }
     width { Faker::Number.decimal(l_digits: 3, r_digits: 1) }
     height { Faker::Number.decimal(l_digits: 3, r_digits: 1) }
+    vin { Faker::Vehicle.vin }
+    license_plate { Faker::Vehicle.license_plate }
     association :company
   end
 end

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Truck, type: :model do
   describe "validations" do
     subject { valid_truck } # Use a valid truck as the baseline for testing
 
+    # Uniqueness Validations
+    it { is_expected.to validate_uniqueness_of(:vin) }
+
     # Presence Validations
     it { is_expected.to validate_presence_of(:make) }
     it { is_expected.to validate_presence_of(:model) }
@@ -21,6 +24,8 @@ RSpec.describe Truck, type: :model do
     it { is_expected.to validate_presence_of(:width) }
     it { is_expected.to validate_presence_of(:height) }
     it { is_expected.to validate_presence_of(:weight) }
+    it { is_expected.to validate_presence_of(:license_plate) }
+    it { is_expected.to validate_presence_of(:vin) }
 
     # Numericality Validations
     it { is_expected.to validate_numericality_of(:length).is_greater_than(0) }
@@ -31,6 +36,8 @@ RSpec.describe Truck, type: :model do
     it { is_expected.to validate_numericality_of(:year).is_greater_than_or_equal_to(1900) }
     it { is_expected.to validate_numericality_of(:mileage).only_integer }
     it { is_expected.to validate_numericality_of(:mileage).is_greater_than_or_equal_to(0) }
+
+    it { is_expected.to validate_length_of(:vin).is_equal_to(17) }
   end
 
   ## Valid Truck Test
@@ -84,14 +91,16 @@ RSpec.describe Truck, type: :model do
   ## Custom Method Tests
   describe "#display_name" do
     it "returns a string formatted as make-model-year" do
-      expect(valid_truck.display_name).to eq("#{valid_truck.make}-#{valid_truck.model}-#{valid_truck.year}")
+      expect(valid_truck.display_name).to eq("#{valid_truck.make}-#{valid_truck.model}-#{valid_truck.year}(#{valid_truck.license_plate})")
     end
 
     it "handles nil values gracefully" do
       valid_truck.make = nil
       valid_truck.model = nil
       valid_truck.year = nil
-      expect(valid_truck.display_name).to eq("--")
+      valid_truck.license_plate = nil
+
+      expect(valid_truck.display_name).to eq("--()")
     end
   end
 end

--- a/spec/requests/trucks_spec.rb
+++ b/spec/requests/trucks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "/trucks", type: :request do
       width: 200.0,
       height: 220.5,
       license_plate: "AXY-1234",
-      vin: "WDBRF61J43F234567"
+      vin: "WDBRF61J43F765432"
     }
   end
 

--- a/spec/requests/trucks_spec.rb
+++ b/spec/requests/trucks_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe "/trucks", type: :request do
       weight: 2000.0,
       length: 5050.0,
       width: 200.0,
-      height: 220.5
+      height: 220.5,
+      license_plate: "AXY-1234",
+      vin: "WDBRF61J43F234567"
     }
   end
 


### PR DESCRIPTION
## Description
Adds VIN and license plate to truck model.

## Approach Taken
Migrations, specs, and view updates.

## What Could Go Wrong?
This is a breaking change since it will invalidate potential pre-existing records in the database. DB will need to be dropped. Done in anticipation of v1.

## Remediation Strategy 
None. Part of the official breaking release in anticipation of v1.
