### PR TITLE
XMDEV-110: Refactor ShipmentStatus and add locked_for_customers attribute

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -234,3 +234,7 @@ button, .primary-button, .secondary-button, .danger-button {
   background-color: #4CAF50;
   color: white;
 }
+
+.center-text {
+  text-align: center;
+}

--- a/app/controllers/shipment_statuses_controller.rb
+++ b/app/controllers/shipment_statuses_controller.rb
@@ -1,7 +1,7 @@
 class ShipmentStatusesController < ApplicationController
-    before_action :set_shipment_status, only: %i[edit update destroy]
     before_action :authenticate_user!
     before_action :ensure_admin
+    before_action :set_shipment_status, only: %i[edit update destroy]
 
     def new
       @shipment_status = ShipmentStatus.new
@@ -38,6 +38,8 @@ class ShipmentStatusesController < ApplicationController
     end
 
     def shipment_status_params
-      params.require(:shipment_status).permit(:company_id, :name)
+      params.require(:shipment_status).permit(:company_id, :name, :locked_for_customers).tap do |whitelisted|
+        whitelisted[:locked_for_customers] = ActiveRecord::Type::Boolean.new.cast(whitelisted[:locked_for_customers])
+      end
     end
 end

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,9 +1,9 @@
 class ShipmentsController < ApplicationController
-  before_action :set_shipment, only: %i[ show edit update destroy ]
   before_action :authenticate_user!
   before_action :authorize_customer, only: [ :new, :create, :destroy, :index ]
   before_action :authorize_driver, only: [ :assign, :assign_shipments_to_truck ]
   before_action :authorize_edit_update, only: [ :edit, :update ]
+  before_action :set_shipment, only: %i[ show edit update destroy ]
 
   # GET /shipments
   def index
@@ -21,12 +21,12 @@ class ShipmentsController < ApplicationController
 
   # GET /shipments/1/edit
   def edit
+    @statuses = current_user.role == "customer" ? [] : ShipmentStatus.for_company(current_company)
   end
 
   # POST /shipments
   def create
     @shipment = Shipment.new(shipment_params)
-    @shipment.shipment_status = ShipmentStatus.find_by(name: "Ready")
     @shipment.user = current_user
 
     if @shipment.save
@@ -120,6 +120,7 @@ class ShipmentsController < ApplicationController
 
     def shipment_params
       params.require(:shipment).permit(
+        :shipment_status_id,
         :name,
         :sender_name,
         :sender_address,

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,9 +1,9 @@
 class ShipmentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_shipment, only: %i[ show edit update destroy ]
   before_action :authorize_customer, only: [ :new, :create, :destroy, :index ]
   before_action :authorize_driver, only: [ :assign, :assign_shipments_to_truck ]
   before_action :authorize_edit_update, only: [ :edit, :update ]
-  before_action :set_shipment, only: %i[ show edit update destroy ]
 
   # GET /shipments
   def index

--- a/app/controllers/trucks_controller.rb
+++ b/app/controllers/trucks_controller.rb
@@ -1,7 +1,7 @@
 class TrucksController < ApplicationController
-  before_action :set_truck, only: %i[ show edit update destroy ]
   before_action :authenticate_user!
   before_action :ensure_admin
+  before_action :set_truck, only: %i[ show edit update destroy ]
 
   # GET /trucks/1
   def show

--- a/app/helpers/shipments_helper.rb
+++ b/app/helpers/shipments_helper.rb
@@ -1,2 +1,25 @@
 module ShipmentsHelper
+  def auto_select_sender(shipment)
+    if current_user && current_user.role == "customer"
+      current_user&.display_name
+    else
+      shipment.sender_name
+    end
+  end
+
+  def auto_select_address(shipment)
+    if current_user && current_user.role == "customer"
+      current_user&.home_address
+    else
+      shipment.sender_address
+    end
+  end
+
+  def locked_fields?(shipment_status)
+    if current_user && current_user.role == "customer" && shipment_status&.locked_for_customers
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -2,7 +2,7 @@ class Shipment < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :company, optional: true
   belongs_to :truck, optional: true
-  belongs_to :shipment_status
+  belongs_to :shipment_status, optional: true
 
   validates :name, :sender_name, :sender_address, :receiver_name, :receiver_address, :weight, :length, :width, :height, :boxes, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -7,6 +7,7 @@
   <thead>
     <tr>
       <th>Name</th>
+      <th class="center-text">Locked for Customers?</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -14,6 +15,13 @@
     <% @shipment_statuses.each do |status| %>
       <tr>
         <td><%= status.name %></td>
+        <td class="center-text">
+          <% if status.locked_for_customers %>
+            ✔️
+          <% else %>
+            ❌
+          <% end %>
+        </td>
         <td>
           <%= link_to 'Edit', edit_shipment_status_path(status), class: 'action-link' %> |
           <%= link_to 'Destroy', status, method: :delete, data: { confirm: 'Are you sure?' }, class: 'action-link danger-link' %>

--- a/app/views/shipment_statuses/_form.html.erb
+++ b/app/views/shipment_statuses/_form.html.erb
@@ -17,6 +17,12 @@
     <%= form.text_field :name, class: 'form-input' %>
   </div>
 
+  <div class="form-group">
+    <%= form.label :locked_for_customers, 'Lock for Customers?', class: 'form-label' %>
+    <%= form.check_box :locked_for_customers, class: 'form-checkbox' %>
+    <small class="help-text">If checked, customers will not be able to update shipments with this status.</small>
+  </div>
+
   <div class="actions">
     <%= form.submit 'Save Shipment Status', class: 'button primary-button' %>
   </div>

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -1,3 +1,15 @@
+<% disabled = locked_fields?(shipment.shipment_status) %>
+
+<% if shipment.company %>
+  <div class="form-group">
+    <p>Shipment has been claimed by <%= shipment.company.name %>.
+      <% if disabled %>
+        No further updates are allowed.
+      <% end %>
+    </p>
+  </div>
+<% end %>
+
 <%= form_with(model: shipment, local: true, class: 'styled-form') do |form| %>
   <% if shipment.errors.any? %>
     <div class="error-messages">
@@ -10,57 +22,67 @@
     </div>
   <% end %>
 
+  <% unless statuses.empty? %>
+    <div class="form-group">
+      <%= form.label :shipment_status_id, "Shipment Status", class: 'form-label' %>
+      <%= form.select :shipment_status_id, 
+                      options_from_collection_for_select(statuses, :id, :name, shipment.shipment_status_id), 
+                      { include_blank: "Select a Status" }, 
+                      { class: 'form-input', disabled: current_user.role == "customer" || disabled } %>
+    </div>
+  <% end %>
+
   <div class="form-group">
     <%= form.label :name, class: 'form-label' %>
-    <%= form.text_field :name, class: 'form-input' %>
+    <%= form.text_field :name, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :sender_name, class: 'form-label' %>
-    <%= form.text_field :sender_name, class: 'form-input', value: current_user&.display_name %>
+    <%= form.text_field :sender_name, class: 'form-input', value: auto_select_sender(shipment), disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :sender_address, class: 'form-label' %>
-    <%= form.text_area :sender_address, class: 'form-input', value: current_user&.home_address %>
+    <%= form.text_area :sender_address, class: 'form-input', value: auto_select_address(shipment), disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :receiver_name, class: 'form-label' %>
-    <%= form.text_field :receiver_name, class: 'form-input' %>
+    <%= form.text_field :receiver_name, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :receiver_address, class: 'form-label' %>
-    <%= form.text_area :receiver_address, class: 'form-input' %>
+    <%= form.text_area :receiver_address, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :weight, class: 'form-label' %>
-    <%= form.text_field :weight, class: 'form-input' %>
+    <%= form.text_field :weight, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :length, class: 'form-label' %>
-    <%= form.text_field :length, class: 'form-input' %>
+    <%= form.text_field :length, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :width, class: 'form-label' %>
-    <%= form.text_field :width, class: 'form-input' %>
+    <%= form.text_field :width, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :height, class: 'form-label' %>
-    <%= form.text_field :height, class: 'form-input' %>
+    <%= form.text_field :height, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-group">
     <%= form.label :boxes, class: 'form-label' %>
-    <%= form.number_field :boxes, class: 'form-input' %>
+    <%= form.number_field :boxes, class: 'form-input', disabled: disabled %>
   </div>
 
   <div class="form-actions">
-    <%= form.submit 'Save Shipment', class: 'button primary-button' %>
+    <%= form.submit 'Save Shipment', class: 'button primary-button', disabled: disabled %>
   </div>
 <% end %>

--- a/app/views/shipments/edit.html.erb
+++ b/app/views/shipments/edit.html.erb
@@ -4,5 +4,5 @@
 </div>
 
 <div class="form-container">
-  <%= render 'form', shipment: @shipment %>
+  <%= render 'form', shipment: @shipment, statuses: @statuses || [] %>
 </div>

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -6,6 +6,7 @@
 <table class="styled-table">
   <thead>
     <tr>
+      <th>Company</th>
       <th>Status</th>
       <th>Name</th>
       <th>Sender</th>
@@ -17,6 +18,7 @@
   <tbody>
     <% @shipments.each do |shipment| %>
       <tr>
+        <td><%= shipment&.company&.name %></td>
         <td><%= shipment.status %></td>
         <td><%= shipment.name %></td>
         <td><%= shipment.sender_name %></td>

--- a/app/views/shipments/new.html.erb
+++ b/app/views/shipments/new.html.erb
@@ -4,5 +4,5 @@
 </div>
 
 <div class="form-container">
-  <%= render 'form', shipment: @shipment %>
+  <%= render 'form', shipment: @shipment, statuses: @statuses || [] %>
 </div>

--- a/db/migrate/20250204014021_remove_not_null_constraint_from_shipment_status_id_on_shipments.rb
+++ b/db/migrate/20250204014021_remove_not_null_constraint_from_shipment_status_id_on_shipments.rb
@@ -1,0 +1,9 @@
+class RemoveNotNullConstraintFromShipmentStatusIdOnShipments < ActiveRecord::Migration[8.0]
+  def up
+    change_column_null :shipments, :shipment_status_id, true
+  end
+
+  def down
+    change_column_null :shipments, :shipment_status_id, false
+  end
+end

--- a/db/migrate/20250204014450_add_locked_for_customers_to_shipment_statuses.rb
+++ b/db/migrate/20250204014450_add_locked_for_customers_to_shipment_statuses.rb
@@ -1,0 +1,7 @@
+class AddLockedForCustomersToShipmentStatuses < ActiveRecord::Migration[8.0]
+  def change
+    unless column_exists?(:shipment_statuses, :locked_for_customers)
+      add_column :shipment_statuses, :locked_for_customers, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_03_045135) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_014450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_045135) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "company_id", null: false
+    t.boolean "locked_for_customers", default: false, null: false
     t.index ["company_id"], name: "index_shipment_statuses_on_company_id"
   end
 
@@ -40,7 +41,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_045135) do
     t.bigint "truck_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "shipment_status_id", null: false
+    t.bigint "shipment_status_id"
     t.bigint "user_id"
     t.bigint "company_id"
     t.decimal "length"
@@ -75,9 +76,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_045135) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.integer "role", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "role", default: 0, null: false
     t.string "first_name"
     t.string "last_name"
     t.string "drivers_license"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -156,9 +156,9 @@ truck5 = Truck.create!(
 
 # Create shipment statuses
 puts "Creating shipment statuses..."
-status1 = ShipmentStatus.create!(name: "Ready", company: company1)
-status2 = ShipmentStatus.create!(name: "In Transit", company: company1)
-status3 = ShipmentStatus.create!(name: "Delivered", company: company1)
+status1 = ShipmentStatus.create!(name: "Ready", company: company1, locked_for_customers: false)
+status2 = ShipmentStatus.create!(name: "In Transit", company: company1, locked_for_customers: true)
+status3 = ShipmentStatus.create!(name: "Delivered", company: company1, locked_for_customers: true)
 
 # Create shipments
 puts "Creating shipments..."
@@ -174,7 +174,7 @@ Shipment.create!(
   width: 100.2,
   height: 100.0,
   truck: truck1,
-  shipment_status: status1,
+  shipment_status: nil,
   user: user5,
   company: company1
 )
@@ -225,7 +225,7 @@ Shipment.create!(
   width: 200.0,
   height: 200.5,
   truck: nil,
-  shipment_status: status1,
+  shipment_status: nil,
   user: user5,
   company: nil
 )
@@ -242,7 +242,7 @@ Shipment.create!(
   width: 100.5,
   height: 100.2,
   truck: nil,
-  shipment_status: status1,
+  shipment_status: nil,
   user: user5,
   company: nil
 )
@@ -327,7 +327,7 @@ Shipment.create!(
   width: 100.2,
   height: 100.3,
   truck: nil,
-  shipment_status: status1,
+  shipment_status: nil,
   user: user5,
   company: nil
 )
@@ -344,7 +344,7 @@ Shipment.create!(
   width: 100.2,
   height: 100.3,
   truck: nil,
-  shipment_status: status1,
+  shipment_status: nil,
   user: user6,
   company: nil
 )

--- a/spec/factories/shipment_statuses.rb
+++ b/spec/factories/shipment_statuses.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :shipment_status do
     name { Faker::Commerce.product_name }
+    locked_for_customers { false }
     association :company
   end
 end

--- a/spec/helpers/shipments_helper_spec.rb
+++ b/spec/helpers/shipments_helper_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe ShipmentsHelper, type: :helper do
+  let(:shipment) { create(:shipment, sender_name: "John Doe", sender_address: "123 Main St") }
+  let(:customer) { create(:user, role: "customer", home_address: "456 Customer St") }
+  let(:admin) { create(:user, role: "admin") }
+  let(:shipment_status_locked) { create(:shipment_status, locked_for_customers: true) }
+  let(:shipment_status_unlocked) { create(:shipment_status, locked_for_customers: false) }
+
+  describe "#auto_select_sender" do
+    context "when the current user is a customer" do
+      before { allow(helper).to receive(:current_user).and_return(customer) }
+
+      it "returns the display_name of the customer" do
+        expect(helper.auto_select_sender(shipment)).to eq("John Doe")
+      end
+    end
+
+    context "when the current user is not a customer" do
+      before { allow(helper).to receive(:current_user).and_return(admin) }
+
+      it "returns the sender_name of the shipment" do
+        expect(helper.auto_select_sender(shipment)).to eq("John Doe")
+      end
+    end
+
+    context "when there is no current user" do
+      before { allow(helper).to receive(:current_user).and_return(nil) }
+
+      it "returns the sender_name of the shipment" do
+        expect(helper.auto_select_sender(shipment)).to eq("John Doe")
+      end
+    end
+  end
+
+  describe "#auto_select_address" do
+    context "when the current user is a customer" do
+      before { allow(helper).to receive(:current_user).and_return(customer) }
+
+      it "returns the home_address of the customer" do
+        expect(helper.auto_select_address(shipment)).to eq("456 Customer St")
+      end
+    end
+
+    context "when the current user is not a customer" do
+      before { allow(helper).to receive(:current_user).and_return(admin) }
+
+      it "returns the sender_address of the shipment" do
+        expect(helper.auto_select_address(shipment)).to eq("123 Main St")
+      end
+    end
+
+    context "when there is no current user" do
+      before { allow(helper).to receive(:current_user).and_return(nil) }
+
+      it "returns the sender_address of the shipment" do
+        expect(helper.auto_select_address(shipment)).to eq("123 Main St")
+      end
+    end
+  end
+
+  describe "#locked_fields?" do
+    context "when the current user is a customer and the shipment status is locked" do
+      before { allow(helper).to receive(:current_user).and_return(customer) }
+
+      it "returns true" do
+        expect(helper.locked_fields?(shipment_status_locked)).to be_truthy
+      end
+    end
+
+    context "when the current user is a customer and the shipment status is unlocked" do
+      before { allow(helper).to receive(:current_user).and_return(customer) }
+
+      it "returns false" do
+        expect(helper.locked_fields?(shipment_status_unlocked)).to be_falsey
+      end
+    end
+
+    context "when the current user is not a customer" do
+      before { allow(helper).to receive(:current_user).and_return(admin) }
+
+      it "returns false regardless of shipment status" do
+        expect(helper.locked_fields?(shipment_status_locked)).to be_falsey
+        expect(helper.locked_fields?(shipment_status_unlocked)).to be_falsey
+      end
+    end
+
+    context "when there is no current user" do
+      before { allow(helper).to receive(:current_user).and_return(nil) }
+
+      it "returns false" do
+        expect(helper.locked_fields?(shipment_status_locked)).to be_falsey
+        expect(helper.locked_fields?(shipment_status_unlocked)).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Shipment, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:truck).optional }
     it { is_expected.to belong_to(:user).optional }
-    it { is_expected.to belong_to(:shipment_status) }
+    it { is_expected.to belong_to(:shipment_status).optional }
     it { is_expected.to belong_to(:company).optional }
   end
 

--- a/spec/requests/shipment_statuses_spec.rb
+++ b/spec/requests/shipment_statuses_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "/shipment_statuses", type: :request do
   let(:valid_attributes) do
     {
       name: "In Transit",
-      company_id: company.id
+      company_id: company.id,
+      locked_for_customers: true
     }
   end
 
@@ -25,7 +26,8 @@ RSpec.describe "/shipment_statuses", type: :request do
 
   let(:new_attributes) do
     {
-      name: "Delivered"
+      name: "Delivered",
+      locked_for_customers: true
     }
   end
 

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "/shipments", type: :request do
   let!(:company) { create(:company) }
 
   let(:admin_user) { create(:user, :admin, company: company) }
-  let(:shipment_status) { create(:shipment_status, name: "Ready") }
 
   let!(:shipment) { create(:shipment, user: valid_user) }
   let!(:other_shipment) { create(:shipment, user: other_user) }
@@ -15,7 +14,6 @@ RSpec.describe "/shipments", type: :request do
   let(:valid_attributes) do
     {
       name: "New Shipment",
-      shipment_status_id: shipment_status.id,
       sender_name: "Sender",
       sender_address: "123 Street",
       receiver_name: "Receiver",


### PR DESCRIPTION
## Description
This PR reworks shipment status so that shipments can be customized for each company

## Approach Taken
Refactor based on each company having their own workflow for shipment statuses.

## What Could Go Wrong?
DB migrations. Therefore

## Remediation Strategy 
Breaking change. Will be part of V1.0.0.
