### PR TITLE
XMDEV-182: Adds status to deliveries

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -2,7 +2,7 @@ class Delivery < ApplicationRecord
   belongs_to :user
   belongs_to :truck
 
-  enum status: {
+  enum :status, {
     scheduled: 0,
     in_progress: 1,
     completed: 2,

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,4 +1,20 @@
 class Delivery < ApplicationRecord
   belongs_to :user
   belongs_to :truck
+  
+  enum status: { 
+    scheduled: 0, 
+    in_progress: 1, 
+    completed: 2, 
+    cancelled: 3 
+  }
+  
+  validates :status, presence: true
+  
+  scope :active, -> { where(status: [:scheduled, :in_progress]) }
+  scope :inactive, -> { where(status: [:completed, :cancelled]) }
+  
+  def active?
+    scheduled? || in_progress?
+  end
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,19 +1,19 @@
 class Delivery < ApplicationRecord
   belongs_to :user
   belongs_to :truck
-  
-  enum status: { 
-    scheduled: 0, 
-    in_progress: 1, 
-    completed: 2, 
-    cancelled: 3 
+
+  enum status: {
+    scheduled: 0,
+    in_progress: 1,
+    completed: 2,
+    cancelled: 3
   }
-  
+
   validates :status, presence: true
-  
-  scope :active, -> { where(status: [:scheduled, :in_progress]) }
-  scope :inactive, -> { where(status: [:completed, :cancelled]) }
-  
+
+  scope :active, -> { where(status: [ :scheduled, :in_progress ]) }
+  scope :inactive, -> { where(status: [ :completed, :cancelled ]) }
+
   def active?
     scheduled? || in_progress?
   end

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -17,4 +17,14 @@ class Truck < ApplicationRecord
   def display_name
     "#{make}-#{model}-#{year}(#{license_plate})"
   end
+
+  # Check if truck is available
+  def available?
+    deliveries.active.none?
+  end
+  
+  # Get the truck's active delivery if any
+  def active_delivery
+    deliveries.active.first
+  end
 end

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -22,7 +22,7 @@ class Truck < ApplicationRecord
   def available?
     deliveries.active.none?
   end
-  
+
   # Get the truck's active delivery if any
   def active_delivery
     deliveries.active.first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,4 +47,14 @@ class User < ApplicationRecord
   def has_company?
     company.present?
   end
+
+  # Check if user is available (not on active delivery)
+  def available?
+    deliveries.active.none?
+  end
+  
+  # Get the user's active delivery if any
+  def active_delivery
+    deliveries.active.first
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
   def available?
     deliveries.active.none?
   end
-  
+
   # Get the user's active delivery if any
   def active_delivery
     deliveries.active.first

--- a/db/migrate/20250302165112_add_status_to_deliveries.rb
+++ b/db/migrate/20250302165112_add_status_to_deliveries.rb
@@ -1,0 +1,9 @@
+class AddStatusToDeliveries < ActiveRecord::Migration[8.0]
+  def change
+    unless column_exists?(:deliveries, :status)
+      add_column :deliveries, :status, :integer, null: false, default: 0
+    end
+
+    add_index :deliveries, :status, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_27_050121) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_02_165112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_27_050121) do
     t.bigint "truck_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
+    t.index ["status"], name: "index_deliveries_on_status"
     t.index ["truck_id"], name: "index_deliveries_on_truck_id"
     t.index ["user_id"], name: "index_deliveries_on_user_id"
   end

--- a/spec/factories/deliveries.rb
+++ b/spec/factories/deliveries.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :delivery do
     association :truck
     association :user
+    status { :scheduled }
   end
 end

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -9,4 +9,69 @@ RSpec.describe Delivery, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:truck) }
   end
+
+  ## Enum Tests
+  describe "enums" do
+    it { is_expected.to define_enum_for(:status).with_values(scheduled: 0, in_progress: 1, completed: 2, cancelled: 3) }
+  end
+
+  ## Validation Tests
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:status) }
+  end
+
+  ## Default Value Tests
+  describe "defaults" do
+    it "defaults status to scheduled" do
+      delivery = Delivery.new
+      expect(delivery.status).to eq("scheduled")
+    end
+  end
+
+  ## Scope Tests
+  describe "scopes" do
+    before do
+      @scheduled_delivery = create(:delivery, status: :scheduled)
+      @in_progress_delivery = create(:delivery, status: :in_progress)
+      @completed_delivery = create(:delivery, status: :completed)
+      @cancelled_delivery = create(:delivery, status: :cancelled)
+    end
+
+    describe ".active" do
+      it "includes scheduled and in_progress deliveries" do
+        expect(Delivery.active).to include(@scheduled_delivery, @in_progress_delivery)
+        expect(Delivery.active).not_to include(@completed_delivery, @cancelled_delivery)
+      end
+    end
+
+    describe ".inactive" do
+      it "includes completed and cancelled deliveries" do
+        expect(Delivery.inactive).to include(@completed_delivery, @cancelled_delivery)
+        expect(Delivery.inactive).not_to include(@scheduled_delivery, @in_progress_delivery)
+      end
+    end
+  end
+
+  ## Instance Method Tests
+  describe "#active?" do
+    it "returns true for scheduled deliveries" do
+      delivery = build(:delivery, status: :scheduled)
+      expect(delivery.active?).to be true
+    end
+
+    it "returns true for in_progress deliveries" do
+      delivery = build(:delivery, status: :in_progress)
+      expect(delivery.active?).to be true
+    end
+
+    it "returns false for completed deliveries" do
+      delivery = build(:delivery, status: :completed)
+      expect(delivery.active?).to be false
+    end
+
+    it "returns false for cancelled deliveries" do
+      delivery = build(:delivery, status: :cancelled)
+      expect(delivery.active?).to be false
+    end
+  end
 end

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -104,4 +104,34 @@ RSpec.describe Truck, type: :model do
       expect(valid_truck.display_name).to eq("--()")
     end
   end
+
+  describe "#available?" do
+    describe "when there is an active delivery" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+      it "returns false" do
+        expect(valid_truck.available?).to eq(false)
+      end
+    end
+
+    describe "when there is not an active delivery" do
+      it "returns true" do
+        expect(valid_truck.available?).to eq(true)
+      end
+    end
+  end
+
+  describe "#active_delivery" do
+    describe "when there is an active delivery" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+      it "returns the delivery" do
+        expect(valid_truck.active_delivery).to eq(delivery)
+      end
+    end
+
+    describe "when there is not an active delivery" do
+      it "returns nil" do
+        expect(valid_truck.active_delivery).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -217,4 +217,34 @@ RSpec.describe User, type: :model do
       expect(valid_user.has_company?).to eq(false)
     end
   end
+
+  describe "#available?" do
+    describe "when there is an active delivery" do
+      let!(:delivery) { create(:delivery, user: valid_user) }
+      it "returns false" do
+        expect(valid_user.available?).to eq(false)
+      end
+    end
+
+    describe "when there is not an active delivery" do
+      it "returns true" do
+        expect(valid_user.available?).to eq(true)
+      end
+    end
+  end
+
+  describe "#active_delivery" do
+    describe "when there is an active delivery" do
+      let!(:delivery) { create(:delivery, user: valid_user) }
+      it "returns the delivery" do
+        expect(valid_user.active_delivery).to eq(delivery)
+      end
+    end
+
+    describe "when there is not an active delivery" do
+      it "returns nil" do
+        expect(valid_user.active_delivery).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
This PR adds a status enum to the deliveries field for tracking delivery status.

## Approach Taken
Wrote the migration and updated the models accordingly.

## What Could Go Wrong?
Care has been taken to write idempotent migrations, so no risk there. Apart from that, the code updates are not used anywhere, so this PR is effectively zero risk.

## Remediation Strategy 
NA. 
