### PR TITLE
XMDEV-186: Adds delivery_shipments table

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -2,6 +2,9 @@ class Delivery < ApplicationRecord
   belongs_to :user
   belongs_to :truck
 
+  has_many :delivery_shipments
+  has_many :shipments, through: :delivery_shipments
+
   enum :status, {
     scheduled: 0,
     in_progress: 1,

--- a/app/models/delivery_shipment.rb
+++ b/app/models/delivery_shipment.rb
@@ -1,0 +1,4 @@
+class DeliveryShipment < ApplicationRecord
+  belongs_to :delivery
+  belongs_to :shipment
+end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -4,6 +4,9 @@ class Shipment < ApplicationRecord
   belongs_to :truck, optional: true
   belongs_to :shipment_status, optional: true
 
+  has_many :delivery_shipments
+  has_many :deliveries, through: :delivery_shipments
+
   validates :name, :sender_name, :sender_address, :receiver_name, :receiver_address, :weight, :length, :width, :height, :boxes, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }
   validates :boxes, numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/db/migrate/20250302201310_create_delivery_shipments.rb
+++ b/db/migrate/20250302201310_create_delivery_shipments.rb
@@ -1,0 +1,10 @@
+class CreateDeliveryShipments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :delivery_shipments, if_not_exists: true do |t|
+      t.references :delivery, null: false, foreign_key: true
+      t.references :shipment, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_02_165112) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_02_201310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -30,6 +30,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_02_165112) do
     t.index ["status"], name: "index_deliveries_on_status"
     t.index ["truck_id"], name: "index_deliveries_on_truck_id"
     t.index ["user_id"], name: "index_deliveries_on_user_id"
+  end
+
+  create_table "delivery_shipments", force: :cascade do |t|
+    t.bigint "delivery_id", null: false
+    t.bigint "shipment_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["delivery_id"], name: "index_delivery_shipments_on_delivery_id"
+    t.index ["shipment_id"], name: "index_delivery_shipments_on_shipment_id"
   end
 
   create_table "shipment_action_preferences", force: :cascade do |t|
@@ -113,6 +122,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_02_165112) do
 
   add_foreign_key "deliveries", "trucks"
   add_foreign_key "deliveries", "users"
+  add_foreign_key "delivery_shipments", "deliveries"
+  add_foreign_key "delivery_shipments", "shipments"
   add_foreign_key "shipment_action_preferences", "companies"
   add_foreign_key "shipment_action_preferences", "shipment_statuses"
   add_foreign_key "shipment_statuses", "companies"

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -15,6 +15,9 @@ erDiagram
     
     ShipmentStatuses ||--o{ ShipmentActionPreferences : used_in
     
+    Deliveries ||--o{ DeliveryShipments : has
+    Shipments ||--o{ DeliveryShipments : included_in
+    
     Companies {
         bigint id PK
         string name
@@ -82,6 +85,14 @@ erDiagram
         decimal length
         decimal width
         decimal height
+        datetime created_at
+        datetime updated_at
+    }
+
+    DeliveryShipments {
+        bigint id PK
+        bigint delivery_id FK
+        bigint shipment_id FK
         datetime created_at
         datetime updated_at
     }

--- a/spec/factories/delivery_shipments.rb
+++ b/spec/factories/delivery_shipments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :delivery_shipment do
+    association :delivery
+    association :shipment
+  end
+end

--- a/spec/models/delivery_shipment_spec.rb
+++ b/spec/models/delivery_shipment_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe DeliveryShipment, type: :model do
+  # Define a valid delivery_shipment object for reuse
+  let(:valid_delivery) { create(:delivery_shipment) }
+
+  ## Association Tests
+  describe "associations" do
+    it { is_expected.to belong_to(:shipment) }
+    it { is_expected.to belong_to(:delivery) }
+  end
+end

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Delivery, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:truck) }
+    it { is_expected.to have_many(:delivery_shipments) }
+    it { is_expected.to have_many(:shipments).through(:delivery_shipments) }
   end
 
   ## Enum Tests

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Shipment, type: :model do
     it { is_expected.to belong_to(:user).optional }
     it { is_expected.to belong_to(:shipment_status).optional }
     it { is_expected.to belong_to(:company).optional }
+    it { is_expected.to have_many(:delivery_shipments) }
+    it { is_expected.to have_many(:deliveries).through(:delivery_shipments) }
   end
 
   ## Validation Tests


### PR DESCRIPTION
## Description
Shipments should be able to go through multiple deliveries until they reach their destination. This PR creates a table dedicated to describing the many-to-many relationship of shipments and deliveries.

## Approach Taken
Creates a dedicated table called DeliveryShipment that will track the deliveries tied to a shipment.

## What Could Go Wrong?
Care was taken to write idempotent migrations, this is a backend change that is not currently used anywhere within the app. Risk is minimized.

## Remediation Strategy 
NA
