### PR TITLE
XMDEV-198: Fixes issue with nil status showing blank field in Shipment:Show

### DIFF
--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -6,11 +6,7 @@
 <div class="details-container">
   <p><strong>Name:</strong> <span class="detail-value"><%= @shipment.name %></span></p>
   <p><strong>Status: </strong>
-    <% if @shipment.shipment_status_id %>
-    <span class="detail-value"><%= @shipment.status %></span>
-    <% else %>
-    <span class="detail-value">No Current Status</span>
-    <% end %>
+    <span class="detail-value"><%= @shipment.shipment_status_id ? @shipment.status : "No Current Status"%></span>
   </p>
   <p><strong>Sender Name:</strong> <span class="detail-value"><%= @shipment.sender_name %></span></p>
   <p><strong>Sender Address:</strong> <span class="detail-value"><%= @shipment.sender_address %></span></p>

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -5,7 +5,13 @@
 
 <div class="details-container">
   <p><strong>Name:</strong> <span class="detail-value"><%= @shipment.name %></span></p>
-  <p><strong>Status:</strong> <span class="detail-value"><%= @shipment.status %></span></p>
+  <p><strong>Status: </strong>
+    <% if @shipment.shipment_status_id %>
+    <span class="detail-value"><%= @shipment.status %></span>
+    <% else %>
+    <span class="detail-value">No Current Status</span>
+    <% end %>
+  </p>
   <p><strong>Sender Name:</strong> <span class="detail-value"><%= @shipment.sender_name %></span></p>
   <p><strong>Sender Address:</strong> <span class="detail-value"><%= @shipment.sender_address %></span></p>
   <p><strong>Receiver Name:</strong> <span class="detail-value"><%= @shipment.receiver_name %></span></p>
@@ -13,7 +19,7 @@
   <p><strong>Weight:</strong> <span class="detail-value"><%= @shipment.weight %> kg</span></p>
   <p><strong>Boxes:</strong> <span class="detail-value"><%= @shipment.boxes %></span></p>
   <% if @shipment.truck && !@current_user.customer? %>
-    <p><strong>Truck:</strong> <span class="detail-value"><%= link_to @shipment.truck.display_name, @shipment.truck %></span></p>
+  <p><strong>Truck:</strong> <span class="detail-value"><%= link_to @shipment.truck.display_name, @shipment.truck %></span></p>
   <% end %>
 </div>
 


### PR DESCRIPTION
## Description
When navigating to a shipment that didn't have a status, the field was showing as blank. This is undesirable since lack of data is no bueno.

## Approach Taken
Adds a conditional check within the view.

## What Could Go Wrong?
Nothing major, this is a cosmetic change within the frontend. It's technically a bug, so this is fixing something that's already gone wrong.

## Remediation Strategy 
NA
