### PR TITLE
XMDEV-195: Adds migration to add successfully_delivered shipment action preference

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -57,6 +57,7 @@ class CompaniesController < ApplicationController
     company.shipment_action_preferences.create([
       { action: "claimed_by_company", shipment_status_id: nil },
       { action: "loaded_onto_truck", shipment_status_id: nil },
-      { action: "out_for_delivery", shipment_status_id: transit_status.id } ])
+      { action: "out_for_delivery", shipment_status_id: transit_status.id },
+      { action: "successfully_delivered", shipment_status_id: nil } ])
   end
 end

--- a/app/models/shipment_action_preference.rb
+++ b/app/models/shipment_action_preference.rb
@@ -6,7 +6,8 @@ class ShipmentActionPreference < ApplicationRecord
   ACTIONS = [
     "claimed_by_company",
     "loaded_onto_truck",
-    "out_for_delivery"
+    "out_for_delivery",
+    "successfully_delivered"
   ]
 
   validates :action, inclusion: { in: ACTIONS }

--- a/db/migrate/20250308035327_add_successfully_delivered_shipment_action_preference_to_companies.rb
+++ b/db/migrate/20250308035327_add_successfully_delivered_shipment_action_preference_to_companies.rb
@@ -1,0 +1,15 @@
+class AddSuccessfullyDeliveredShipmentActionPreferenceToCompanies < ActiveRecord::Migration[8.0]
+  def up
+    Company.find_each do |company|
+      ShipmentActionPreference.find_or_create_by!(
+        action: "successfully_delivered",
+        company_id: company.id,
+        shipment_status: nil
+      )
+    end
+  end
+
+  def down
+    ShipmentActionPreference.where(action: "successfully_delivered", shipment_status: nil).delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_02_201310) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_08_035327) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,7 @@ ShipmentStatus.destroy_all
 Truck.destroy_all
 User.destroy_all
 Company.destroy_all
+ShipmentActionPreference.destroy_all
 
 # Create companies
 puts "Creating companies..."
@@ -267,10 +268,13 @@ puts "Creating shipment action preferences..."
 ShipmentActionPreference.create!(action: "claimed_by_company", company: company1, shipment_status_id: nil)
 ShipmentActionPreference.create!(action: "loaded_onto_truck", company: company1, shipment_status_id: nil)
 ShipmentActionPreference.create!(action: "out_for_delivery", company: company1, shipment_status: status2)
+ShipmentActionPreference.create!(action: "successfully_delivered", company: company1, shipment_status: status3)
 
 ShipmentActionPreference.create!(action: "claimed_by_company", company: company2, shipment_status_id: status4)
 ShipmentActionPreference.create!(action: "loaded_onto_truck", company: company2, shipment_status_id: nil)
 ShipmentActionPreference.create!(action: "out_for_delivery", company: company2, shipment_status: status2)
+ShipmentActionPreference.create!(action: "successfully_delivered", company: company2, shipment_status: status6)
+
 
 # Create shipments
 puts "Creating shipments..."

--- a/spec/models/shipment_action_preference_spec.rb
+++ b/spec/models/shipment_action_preference_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe ShipmentActionPreference, type: :model do
       expected_actions = [
         "claimed_by_company",
         "loaded_onto_truck",
-        "out_for_delivery"
+        "out_for_delivery",
+        "successfully_delivered"
       ]
       expect(ShipmentActionPreference::ACTIONS).to match_array(expected_actions)
     end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "/companies", type: :request do
         it 'creates the default shipment action preferences' do
           expect {
             post companies_url, params: { company: valid_attributes }
-          }.to change(ShipmentActionPreference, :count).by(3)
+          }.to change(ShipmentActionPreference, :count).by(4)
         end
       end
 


### PR DESCRIPTION
## Description
We want to give drivers the ability to click a button and close a shipment. We'll do this through ShipmentActionPreferences. We added a new one and backfilled it for all companies.

## Approach Taken
Describe the approach you used to solve the problem. Did you consider any other solutions? What made you choose this one?

## What Could Go Wrong?
This is a data migration, so it carries all the risks associated with a migration. The migration has been written with idempotence in mind, so it is safe to run multiple times.

## Remediation Strategy 
Rollback if needed.
