### PR TITLE
Button quick close

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,6 +1,6 @@
 class ShipmentsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_shipment, only: %i[ show edit update destroy ]
+  before_action :set_shipment, only: %i[ show edit update destroy close]
   before_action :authorize_customer, only: [ :new, :create, :destroy, :index ]
   before_action :authorize_driver, only: [ :assign, :assign_shipments_to_truck, :initiate_delivery ]
   before_action :authorize_edit_update, only: [ :edit, :update ]
@@ -49,6 +49,12 @@ class ShipmentsController < ApplicationController
   def destroy
     @shipment.destroy!
     redirect_to shipments_path, status: :see_other, notice: "Shipment was successfully destroyed."
+  end
+
+  def close 
+    preference = current_company.shipment_action_preferences.find_by(action: "successfully_delivered")
+    @shipment.update!(shipment_status_id: preference.shipment_status_id) if preference&.shipment_status_id
+    redirect_to delivery_path(@shipment.active_delivery)
   end
 
   def assign

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -51,7 +51,7 @@ class ShipmentsController < ApplicationController
     redirect_to shipments_path, status: :see_other, notice: "Shipment was successfully destroyed."
   end
 
-  def close 
+  def close
     preference = current_company.shipment_action_preferences.find_by(action: "successfully_delivered")
     @shipment.update!(shipment_status_id: preference.shipment_status_id) if preference&.shipment_status_id
     redirect_to delivery_path(@shipment.active_delivery)

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -2,7 +2,7 @@ class ShipmentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_shipment, only: %i[ show edit update destroy close]
   before_action :authorize_customer, only: [ :new, :create, :destroy, :index ]
-  before_action :authorize_driver, only: [ :assign, :assign_shipments_to_truck, :initiate_delivery ]
+  before_action :authorize_driver, only: [ :assign, :assign_shipments_to_truck, :initiate_delivery, :close ]
   before_action :authorize_edit_update, only: [ :edit, :update ]
 
   # GET /shipments
@@ -53,8 +53,16 @@ class ShipmentsController < ApplicationController
 
   def close
     preference = current_company.shipment_action_preferences.find_by(action: "successfully_delivered")
-    @shipment.update!(shipment_status_id: preference.shipment_status_id) if preference&.shipment_status_id
-    redirect_to delivery_path(@shipment.active_delivery)
+    unless preference&.shipment_status_id
+      return redirect_to delivery_path(@shipment.active_delivery), alert: "No preference set."
+    end
+
+    if preference.shipment_status_id == @shipment.shipment_status_id
+      return redirect_to delivery_path(@shipment.active_delivery), alert: "Shipment is already closed."
+    end
+
+    @shipment.update!(shipment_status_id: preference.shipment_status_id)
+    redirect_to delivery_path(@shipment.active_delivery), notice: "Shipment successfully closed."
   end
 
   def assign

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -26,4 +26,8 @@ class Shipment < ApplicationRecord
   def open?
     !shipment_status&.closed
   end
+
+  def active_delivery
+    deliveries.active.first
+  end
 end

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -25,6 +25,10 @@
       <td><%= shipment.receiver_name %></td>
       <td><%= shipment.weight %></td>
       <td>
+        <%= link_to 'Quick Close', close_shipment_path(shipment), 
+            class: 'action-link', 
+            method: :post, 
+            data: { confirm: 'Was this shipment successfully delivered?' } %> |
         <%= link_to 'Show', shipment, class: 'action-link' %>
       </td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   resources :shipment_action_preferences, only: %i[edit update]
 
   resources :shipments do
-    member do 
+    member do
       post :close
     end
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
   resources :shipment_action_preferences, only: %i[edit update]
 
   resources :shipments do
+    member do 
+      post :close
+    end
     collection do
       post :assign
       post :assign_shipments_to_truck

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -163,4 +163,20 @@ RSpec.describe Shipment, type: :model do
       end
     end
   end
+
+  describe "#active_delivery" do
+    describe "when there is an active delivery" do
+      let!(:delivery) { create(:delivery) }
+      let!(:delivery_shipment) { create(:delivery_shipment, delivery: delivery, shipment: valid_shipment) }
+      it "returns the delivery" do
+        expect(valid_shipment.active_delivery).to eq(delivery)
+      end
+    end
+
+    describe "when there is not an active delivery" do
+      it "returns nil" do
+        expect(valid_shipment.active_delivery).to be_nil
+      end
+    end
+  end
 end

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -648,6 +648,20 @@ RSpec.describe "/shipments", type: :request do
           expect(response).to redirect_to(delivery_url(claimed_shipment.active_delivery))
         end
       end
+
+      context "when the shipment is claimed by another company" do
+        let(:company2) { create(:company) }
+        let!(:other_shipment) { create(:shipment, company: company2) }
+        it "shows the correct alert" do
+          post close_shipment_url(other_shipment)
+          expect(flash[:alert]).to eq("You are not authorized to access this shipment.")
+        end
+
+        it "redirects to the root page" do
+          post close_shipment_url(other_shipment)
+          expect(response).to redirect_to(deliveries_url)
+        end
+      end
     end
 
     describe "DELETE #destroy" do

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe "/shipments", type: :request do
           expect(flash[:alert]).to eq("You are not authorized to access this shipment.")
         end
 
-        it "redirects to the root page" do
+        it "redirects to the deliveries index page" do
           post close_shipment_url(other_shipment)
           expect(response).to redirect_to(deliveries_url)
         end

--- a/spec/routing/shipments_routing_spec.rb
+++ b/spec/routing/shipments_routing_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe ShipmentsController, type: :routing do
       expect(get: "/shipments/1/edit").to route_to("shipments#edit", id: "1")
     end
 
+    it "routes to #close" do
+      expect(post: "/shipments/1/close").to route_to("shipments#close", id: "1")
+    end
 
     it "routes to #create" do
       expect(post: "/shipments").to route_to("shipments#create")


### PR DESCRIPTION
## Description
This PR adds the ability to quick close a shipment while it's out for delivery.

## Approach Taken
New controller action, route and specs.

## What Could Go Wrong?
Nothing really. New functionality. Thoroughly tested

## Remediation Strategy 
Rollback if needed.
