### PR TITLE
XMDEV-203: Updates back button for shipments to return to the referrer to prevent complex logic

### DIFF
--- a/app/views/shipments/_back_button.html.erb
+++ b/app/views/shipments/_back_button.html.erb
@@ -1,9 +1,1 @@
-<% if current_user.customer? %>
-<%= link_to 'Back', shipments_path, class: 'button secondary-button' %>
-<% else %>
-<% if shipment.claimed? %>
-<%= link_to 'Back', load_truck_deliveries_path, class: 'button secondary-button' %>
-<% else %>
-<%= link_to 'Back', deliveries_path, class: 'button secondary-button' %>
-<% end %>
-<% end %>
+<%= link_to 'Back', request.referrer, class: 'button secondary-button' %>

--- a/app/views/shipments/_back_button.html.erb
+++ b/app/views/shipments/_back_button.html.erb
@@ -1,1 +1,3 @@
-<%= link_to 'Back', request.referrer, class: 'button secondary-button' %>
+<% back_path = request.referrer.present? && URI(request.referrer).host == request.host ? request.referrer : root_path %>
+
+<%= link_to 'Back', back_path, class: 'button secondary-button' %>


### PR DESCRIPTION
## Description
The logic for navigating back a page on shipment show was getting complex. Refactors for a simple, more adaptable approach that is role agnostic.

## Approach Taken
REQUEST.REFERRER!

## What Could Go Wrong?
So there are a couple edge cases here:
- Users can go directly to the page, which would make `request.referrer` nil. In this case, we have a fallback to the root path
- Some browsers block request.referrer functionality. Once again, this is mitigated by our fallback (root path)
- In some extreme cases, a malicious user could point request.referrer to a malicious site. Therefore, we specify that the referrer needs to be tied to the same host.

Simply put, precautions have been taken.

## Remediation Strategy 
NA
