### PR TITLE
XMDEV-208: Removes boxes column from shipments

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -149,8 +149,6 @@ class ShipmentsController < ApplicationController
         :weight,
         :length,
         :width,
-        :height,
-        :boxes
-        )
+        :height)
     end
 end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -7,9 +7,8 @@ class Shipment < ApplicationRecord
   has_many :delivery_shipments
   has_many :deliveries, through: :delivery_shipments
 
-  validates :name, :sender_name, :sender_address, :receiver_name, :receiver_address, :weight, :length, :width, :height, :boxes, presence: true
+  validates :name, :sender_name, :sender_address, :receiver_name, :receiver_address, :weight, :length, :width, :height, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }
-  validates :boxes, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :unassigned, -> { where(user_id: nil) }
 

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -77,11 +77,6 @@
   <%= form.text_field :height, class: 'form-input', disabled: disabled %>
 </div>
 
-<div class="form-group">
-  <%= form.label :boxes, class: 'form-label' %>
-  <%= form.number_field :boxes, class: 'form-input', disabled: disabled %>
-</div>
-
 <div class="form-actions">
   <%= form.submit 'Save Shipment', class: 'button primary-button', disabled: disabled %>
 </div>

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -16,7 +16,6 @@
   <p><strong>Length:</strong> <span class="detail-value"><%= @shipment.length %> cm</span></p>
   <p><strong>Width:</strong> <span class="detail-value"><%= @shipment.width %> cm</span></p>
   <p><strong>Height:</strong> <span class="detail-value"><%= @shipment.height %> cm</span></p>
-  <p><strong>Boxes:</strong> <span class="detail-value"><%= @shipment.boxes %></span></p>
   <% if @shipment.truck && !@current_user.customer? %>
   <p><strong>Truck:</strong> <span class="detail-value"><%= link_to @shipment.truck.display_name, @shipment.truck %></span></p>
   <% end %>

--- a/db/migrate/20250309045158_remove_boxes_from_shipments.rb
+++ b/db/migrate/20250309045158_remove_boxes_from_shipments.rb
@@ -1,0 +1,13 @@
+class RemoveBoxesFromShipments < ActiveRecord::Migration[8.0]
+  def up
+    if column_exists?(:shipments, :boxes)
+      remove_column :shipments, :boxes
+    end
+  end
+
+  def down
+    unless column_exists?(:shipments, :boxes)
+      add_column :shipments, :boxes, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_08_035327) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_09_045158) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,7 +68,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_08_035327) do
     t.string "receiver_name"
     t.text "receiver_address"
     t.decimal "weight"
-    t.integer "boxes"
     t.bigint "truck_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -284,8 +284,7 @@ Shipment.create!(
   sender_address: "101 Tech Blvd, Silicon Valley, USA",
   receiver_name: "GadgetCo",
   receiver_address: "789 Innovation St, New York, USA",
-  weight: 35.0,
-  boxes: 10,
+  weight: 3.5,
   length: 60.0,
   width: 40.0,
   height: 30.0,
@@ -301,8 +300,7 @@ Shipment.create!(
   sender_address: "456 Home Decor Ave, Chicago, USA",
   receiver_name: "DecoLuxe",
   receiver_address: "321 Style St, Boston, USA",
-  weight: 250.0,
-  boxes: 5,
+  weight: 50.0,
   length: 200.0,
   width: 100.0,
   height: 80.0,
@@ -318,8 +316,7 @@ Shipment.create!(
   sender_address: "123 Wellness St, Denver, USA",
   receiver_name: "MediCenter",
   receiver_address: "456 Care Rd, Austin, USA",
-  weight: 120.0,  # Medical equipment can be heavy but not extreme
-  boxes: 15,
+  weight: 8.0,
   length: 80.0,
   width: 60.0,
   height: 50.0,
@@ -335,8 +332,7 @@ Shipment.create!(
   sender_address: "789 Home Ln, Seattle, USA",
   receiver_name: "CozyLiving",
   receiver_address: "321 Comfort Blvd, Boston, USA",
-  weight: 320.0,  # 8 boxes of furniture
-  boxes: 8,
+  weight: 40.0,
   length: 220.0,
   width: 120.0,
   height: 90.0,
@@ -352,8 +348,7 @@ Shipment.create!(
   sender_address: "100 Style Ave, Miami, USA",
   receiver_name: "Trendy Threads",
   receiver_address: "200 Chic St, Los Angeles, USA",
-  weight: 60.0,   # Clothing is relatively light
-  boxes: 20,
+  weight: 3.0,
   length: 60.0,
   width: 40.0,
   height: 30.0,
@@ -369,8 +364,7 @@ Shipment.create!(
   sender_address: "55 Tech St, San Francisco, USA",
   receiver_name: "ElectroWorld",
   receiver_address: "77 Digital Rd, Dallas, USA",
-  weight: 45.0,   # Accessories are lighter than main electronics
-  boxes: 30,
+  weight: 3.0,
   length: 50.0,
   width: 40.0,
   height: 30.0,
@@ -386,8 +380,7 @@ Shipment.create!(
   sender_address: "123 Read Blvd, Portland, USA",
   receiver_name: "City Library",
   receiver_address: "456 Knowledge Ave, Chicago, USA",
-  weight: 400.0,  # Books are very heavy (40 boxes)
-  boxes: 40,
+  weight: 10.0,
   length: 40.0,
   width: 30.0,
   height: 25.0,
@@ -403,8 +396,7 @@ Shipment.create!(
   sender_address: "99 Game Rd, Orlando, USA",
   receiver_name: "PlayNation",
   receiver_address: "88 Fitness Blvd, Atlanta, USA",
-  weight: 90.0,   # Varied equipment weights
-  boxes: 12,
+  weight: 7.5,
   length: 80.0,
   width: 60.0,
   height: 50.0,
@@ -420,8 +412,7 @@ Shipment.create!(
   sender_address: "67 Power Ln, Houston, USA",
   receiver_name: "HomeTech",
   receiver_address: "34 Comfort Rd, Philadelphia, USA",
-  weight: 350.0,  # Appliances are heavy
-  boxes: 18,
+  weight: 19.44,
   length: 90.0,
   width: 70.0,
   height: 80.0,
@@ -437,8 +428,7 @@ Shipment.create!(
   sender_address: "101 Fun St, Minneapolis, USA",
   receiver_name: "KidsLand",
   receiver_address: "555 Happy Blvd, Charlotte, USA",
-  weight: 75.0,   # Toys vary in weight but generally lighter
-  boxes: 25,
+  weight: 3.0,
   length: 60.0,
   width: 50.0,
   height: 40.0,
@@ -454,8 +444,7 @@ Shipment.create!(
   sender_address: "101 Fun St, Minneapolis, USA",
   receiver_name: "KidsLand",
   receiver_address: "555 Happy Blvd, Charlotte, USA",
-  weight: 5.0,    # Action figures are very light
-  boxes: 2,
+  weight: 2.5,
   length: 40.0,
   width: 30.0,
   height: 20.0,
@@ -467,33 +456,33 @@ Shipment.create!(
 
 
 Shipment.create!([
-  { name: "Electronics", sender_name: "ElectroCorp", sender_address: "500 Circuit Ave, San Jose, USA", receiver_name: "TechMart", receiver_address: "222 Innovation Dr, Austin, USA", weight: 160.0, boxes: 45, length: 60.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user5, company: nil },
+  { name: "Electronics", sender_name: "ElectroCorp", sender_address: "500 Circuit Ave, San Jose, USA", receiver_name: "TechMart", receiver_address: "222 Innovation Dr, Austin, USA", weight: 3.55, length: 60.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user5, company: nil },
 
-  { name: "Books", sender_name: "ReadMore", sender_address: "88 Library Ln, Boston, USA", receiver_name: "BookWorld", receiver_address: "777 Novel St, Seattle, USA", weight: 300.0, boxes: 30, length: 40.0, width: 30.0, height: 25.0, truck: nil, shipment_status: nil, user: user5, company: company2 },
+  { name: "Books", sender_name: "ReadMore", sender_address: "88 Library Ln, Boston, USA", receiver_name: "BookWorld", receiver_address: "777 Novel St, Seattle, USA", weight: 10.0, length: 40.0, width: 30.0, height: 25.0, truck: nil, shipment_status: nil, user: user5, company: company2 },
 
-  { name: "Furniture", sender_name: "HomeComfort", sender_address: "99 Cozy Rd, Chicago, USA", receiver_name: "HouseStyle", receiver_address: "333 Living Way, Miami, USA", weight: 380.0, boxes: 15, length: 200.0, width: 120.0, height: 90.0, truck: nil, shipment_status: nil, user: user5, company: company2 },
+  { name: "Furniture", sender_name: "HomeComfort", sender_address: "99 Cozy Rd, Chicago, USA", receiver_name: "HouseStyle", receiver_address: "333 Living Way, Miami, USA", weight: 25.0, length: 200.0, width: 120.0, height: 90.0, truck: nil, shipment_status: nil, user: user5, company: company2 },
 
-  { name: "Clothing", sender_name: "FashionHub", sender_address: "123 Trendy Ave, New York, USA", receiver_name: "WearItAll", receiver_address: "444 Runway St, Los Angeles, USA", weight: 150.0, boxes: 50, length: 60.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user5, company: nil },
+  { name: "Clothing", sender_name: "FashionHub", sender_address: "123 Trendy Ave, New York, USA", receiver_name: "WearItAll", receiver_address: "444 Runway St, Los Angeles, USA", weight: 3.0, length: 60.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user5, company: nil },
 
-  { name: "Sports Equipment", sender_name: "AthletiCo", sender_address: "456 Fit St, Denver, USA", receiver_name: "ActiveZone", receiver_address: "888 Play Blvd, Phoenix, USA", weight: 140.0, boxes: 20, length: 80.0, width: 60.0, height: 50.0, truck: nil, shipment_status: nil, user: user5, company: nil },
+  { name: "Sports Equipment", sender_name: "AthletiCo", sender_address: "456 Fit St, Denver, USA", receiver_name: "ActiveZone", receiver_address: "888 Play Blvd, Phoenix, USA", weight: 7.0, length: 80.0, width: 60.0, height: 50.0, truck: nil, shipment_status: nil, user: user5, company: nil },
 
-  { name: "Appliances", sender_name: "KitchenPro", sender_address: "789 Cook Ln, Houston, USA", receiver_name: "HomeNeeds", receiver_address: "666 Utility Rd, Dallas, USA", weight: 400.0, boxes: 10, length: 90.0, width: 80.0, height: 70.0, truck: nil, shipment_status: nil, user: user5, company: nil },
+  { name: "Appliances", sender_name: "KitchenPro", sender_address: "789 Cook Ln, Houston, USA", receiver_name: "HomeNeeds", receiver_address: "666 Utility Rd, Dallas, USA", weight: 40.0, length: 90.0, width: 80.0, height: 70.0, truck: nil, shipment_status: nil, user: user5, company: nil },
 
-  { name: "Garden Tools", sender_name: "GreenThumb", sender_address: "321 Bloom Dr, Portland, USA", receiver_name: "GrowMore", receiver_address: "111 Nature St, San Diego, USA", weight: 120.0, boxes: 18, length: 70.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user6, company: nil },
+  { name: "Garden Tools", sender_name: "GreenThumb", sender_address: "321 Bloom Dr, Portland, USA", receiver_name: "GrowMore", receiver_address: "111 Nature St, San Diego, USA", weight: 6.67, length: 70.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user6, company: nil },
 
-  { name: "Medical Supplies", sender_name: "MediCare", sender_address: "654 Health St, Atlanta, USA", receiver_name: "Wellness Center", receiver_address: "999 Recovery Rd, Nashville, USA", weight: 130.0, boxes: 25, length: 70.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user6, company: nil },
+  { name: "Medical Supplies", sender_name: "MediCare", sender_address: "654 Health St, Atlanta, USA", receiver_name: "Wellness Center", receiver_address: "999 Recovery Rd, Nashville, USA", weight: 5.2, length: 70.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user6, company: nil },
 
-  { name: "Toys", sender_name: "ToyFactory", sender_address: "101 Fun St, Minneapolis, USA", receiver_name: "KidsLand", receiver_address: "555 Happy Blvd, Charlotte, USA", weight: 75.0, boxes: 25, length: 60.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user5, company: nil },
+  { name: "Toys", sender_name: "ToyFactory", sender_address: "101 Fun St, Minneapolis, USA", receiver_name: "KidsLand", receiver_address: "555 Happy Blvd, Charlotte, USA", weight: 3.0, length: 60.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user5, company: nil },
 
-  { name: "Office Supplies", sender_name: "OfficeMart", sender_address: "987 Work Ave, Philadelphia, USA", receiver_name: "BizSupply", receiver_address: "121 Productivity Blvd, Las Vegas, USA", weight: 110.0, boxes: 35, length: 50.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user6, company: nil },
+  { name: "Office Supplies", sender_name: "OfficeMart", sender_address: "987 Work Ave, Philadelphia, USA", receiver_name: "BizSupply", receiver_address: "121 Productivity Blvd, Las Vegas, USA", weight: 3.14, length: 50.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user6, company: nil },
 
-  { name: "Bicycles", sender_name: "CycleWorks", sender_address: "222 Pedal Rd, Columbus, USA", receiver_name: "RideFast", receiver_address: "333 Trail Ln, Memphis, USA", weight: 180.0, boxes: 12, length: 150.0, width: 30.0, height: 80.0, truck: nil, shipment_status: nil, user: user6, company: company2 },
+  { name: "Bicycles", sender_name: "CycleWorks", sender_address: "222 Pedal Rd, Columbus, USA", receiver_name: "RideFast", receiver_address: "333 Trail Ln, Memphis, USA", weight: 15.0, length: 150.0, width: 30.0, height: 80.0, truck: nil, shipment_status: nil, user: user6, company: company2 },
 
-  { name: "Groceries", sender_name: "FreshFoods", sender_address: "555 Market St, Omaha, USA", receiver_name: "DailyMart", receiver_address: "444 Grocery Ln, Kansas City, USA", weight: 250.0, boxes: 50, length: 50.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user6, company: nil },
+  { name: "Groceries", sender_name: "FreshFoods", sender_address: "555 Market St, Omaha, USA", receiver_name: "DailyMart", receiver_address: "444 Grocery Ln, Kansas City, USA", weight: 5.0, length: 50.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user6, company: nil },
 
-  { name: "Pet Supplies", sender_name: "PawPalace", sender_address: "789 Bark Blvd, St. Louis, USA", receiver_name: "FurryFriends", receiver_address: "888 Woof Way, Indianapolis, USA", weight: 90.0, boxes: 22, length: 60.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user6, company: company2 },
+  { name: "Pet Supplies", sender_name: "PawPalace", sender_address: "789 Bark Blvd, St. Louis, USA", receiver_name: "FurryFriends", receiver_address: "888 Woof Way, Indianapolis, USA", weight: 4.1, length: 60.0, width: 50.0, height: 40.0, truck: nil, shipment_status: nil, user: user6, company: company2 },
 
-  { name: "Cosmetics", sender_name: "BeautyGlow", sender_address: "234 Glam Ave, Detroit, USA", receiver_name: "MakeUpMart", receiver_address: "777 Chic St, Louisville, USA", weight: 70.0, boxes: 28, length: 50.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user6, company: company2 }
+  { name: "Cosmetics", sender_name: "BeautyGlow", sender_address: "234 Glam Ave, Detroit, USA", receiver_name: "MakeUpMart", receiver_address: "777 Chic St, Louisville, USA", weight: 2.5, length: 50.0, width: 40.0, height: 30.0, truck: nil, shipment_status: nil, user: user6, company: company2 }
 ])
 
 

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -77,7 +77,6 @@ erDiagram
         string receiver_name
         text receiver_address
         decimal weight
-        integer boxes
         bigint truck_id FK
         bigint shipment_status_id FK
         bigint user_id FK

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     length { Faker::Number.decimal(l_digits: 2, r_digits: 1) }
     width { Faker::Number.decimal(l_digits: 2, r_digits: 1) }
     height { Faker::Number.decimal(l_digits: 2, r_digits: 1) }
-    boxes { Faker::Number.between(from: 1, to: 100) }
 
     association :truck
     association :shipment_status

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -31,15 +31,12 @@ RSpec.describe Shipment, type: :model do
     it { is_expected.to validate_presence_of(:length) }
     it { is_expected.to validate_presence_of(:width) }
     it { is_expected.to validate_presence_of(:height) }
-    it { is_expected.to validate_presence_of(:boxes) }
 
     # Numericality Validations
     it { is_expected.to validate_numericality_of(:weight).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:length).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:width).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:height).is_greater_than(0) }
-    it { is_expected.to validate_numericality_of(:boxes).only_integer }
-    it { is_expected.to validate_numericality_of(:boxes).is_greater_than_or_equal_to(0) }
   end
 
   ## Valid Shipment Test
@@ -65,11 +62,6 @@ RSpec.describe Shipment, type: :model do
       valid_shipment.weight = 0
       expect(valid_shipment).not_to be_valid
     end
-
-    it "is invalid with a negative number of boxes" do
-      valid_shipment.boxes = -1
-      expect(valid_shipment).not_to be_valid
-    end
   end
 
   ## Scope Tests
@@ -90,19 +82,9 @@ RSpec.describe Shipment, type: :model do
 
   ## Edge Case Tests
   describe "edge cases" do
-    it "allows zero boxes" do
-      valid_shipment.boxes = 0
-      expect(valid_shipment).to be_valid
-    end
-
     it "handles extremely large weights" do
       valid_shipment.weight = 10_000.99
       expect(valid_shipment).to be_valid
-    end
-
-    it "does not allow non-integer values for boxes" do
-      valid_shipment.boxes = 5.5
-      expect(valid_shipment).not_to be_valid
     end
   end
 

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "/shipments", type: :request do
       weight: 50.0,
       length: 50.0,
       width: 20.0,
-      height: 22.5,
-      boxes: 5
+      height: 22.5
     }
   end
 
@@ -34,7 +33,6 @@ RSpec.describe "/shipments", type: :request do
       receiver_name: nil,
       receiver_address: nil,
       weight: nil,
-      boxes: nil
     }
   end
 

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "/shipments", type: :request do
       sender_address: nil,
       receiver_name: nil,
       receiver_address: nil,
-      weight: nil,
+      weight: nil
     }
   end
 


### PR DESCRIPTION
## Description
Removes the boxes column from shipments.

## Approach Taken
We want to make shipment management more granular. Therefore, we're removing the boxes column. We'll be creating a copy action as well.

## What Could Go Wrong?
Nothing major. Idempotent migration is written, so if it should fail, we can rerun.

## Remediation Strategy 
Rollback if needed.
