### PR TITLE
XMDEV-177: Fix flaky tests by ensuring Faker resets each time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               - 'app/mailers/**'
               - 'db/migrate/**'
               - 'config/**'
+              - 'spec/**'
               - 'lib/**'
               - 'Gemfile'
               - 'Gemfile.lock'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,10 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
+  config.before(:each) do
+    Faker::UniqueGenerator.clear
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
## Description
Some test runs in CI were flaking due to parallel_tests being flaky. 

## Approach Taken
Adds the reset config option.

## What Could Go Wrong?
This is a change to alleviate the flakiness of some tests. This is technically a bug fix.

## Remediation Strategy 
NA
