### PR TITLE
XMDEV-111: Adds pundit access control to deliveries and shipments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "thruster", require: false
 
 ## Manually added Gems
 gem "devise"
+gem "pundit" # For access control
 
 gem "parallel_tests", group: [ :development, :test ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,8 @@ GEM
     public_suffix (6.0.1)
     puma (6.6.0)
       nio4r (~> 2.0)
+    pundit (2.5.0)
+      activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.11)
@@ -428,6 +430,7 @@ DEPENDENCIES
   propshaft
   pry
   puma (>= 5.0)
+  pundit
   rails (~> 8.0.1)
   rails-controller-testing
   rspec-rails (~> 7.1)

--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -1,17 +1,19 @@
 class DeliveriesController < ApplicationController
   before_action :authenticate_user!
-  before_action :authorize_driver
   before_action :set_delivery, only: [ :show, :close ]
 
   def index
+    authorize Delivery
     @unassigned_shipments = Shipment.where(company_id: nil)
     @my_shipments = Shipment.where(company_id: current_company)
   end
 
   def show
+    authorize @delivery
   end
 
   def close
+    authorize @delivery
     if @delivery.can_be_closed?
       @delivery.update!(status: :completed)
       return redirect_to start_deliveries_path, notice: "Delivery complete!"
@@ -21,11 +23,13 @@ class DeliveriesController < ApplicationController
   end
 
   def load_truck
+    authorize Delivery
     @unassigned_shipments = Shipment.for_company(current_company).where(truck_id: nil)
     @trucks = Truck.for_company(current_company).select(&:available?)
   end
 
   def start
+    authorize Delivery
     @trucks = Truck.for_company(current_company)
     @active_delivery = current_user.active_delivery
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/delivery_policy.rb
+++ b/app/policies/delivery_policy.rb
@@ -1,0 +1,27 @@
+class DeliveryPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  def index?
+    user.admin? || user.driver?
+  end
+
+  def show?
+    user.admin? || user.driver?
+  end
+
+  def close?
+    user.admin? || user.driver?
+  end
+
+  def load_truck?
+    user.admin? || user.driver?
+  end
+
+  def start?
+    user.admin? || user.driver?
+  end
+end

--- a/app/policies/shipment_policy.rb
+++ b/app/policies/shipment_policy.rb
@@ -1,0 +1,62 @@
+class ShipmentPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  attr_reader :user, :shipment
+
+  def initialize(user, shipment)
+    @user = user
+    @shipment = shipment
+  end
+
+  def index?
+    user.customer?
+  end
+
+  def show?
+    true # Anyone can view a shipment
+  end
+
+  def new?
+    user.customer?
+  end
+
+  def edit?
+    user.customer? || shipment.company_id == user.company_id
+  end
+
+  def create?
+    user.customer?
+  end
+
+  def update?
+    user.customer? || shipment.company_id == user.company_id
+  end
+
+  def destroy?
+    user.customer?
+  end
+
+  def copy?
+    user.customer?
+  end
+
+  def close?
+    user.admin? || user.driver?
+  end
+
+  def assign?
+    user.admin? || user.driver?
+  end
+
+  def assign_shipments_to_truck?
+    user.admin? || user.driver?
+  end
+
+  def initiate_delivery?
+    user.admin? || user.driver?
+  end
+end

--- a/spec/policies/delivery_policy_spec.rb
+++ b/spec/policies/delivery_policy_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe DeliveryPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  let(:delivery) { Delivery.new } # Mock delivery object
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, delivery) }
+
+      it { expect(subject.index?).to be true }
+      it { expect(subject.show?).to be true }
+      it { expect(subject.close?).to be true }
+      it { expect(subject.load_truck?).to be true }
+      it { expect(subject.start?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, delivery) }
+
+      it { expect(subject.index?).to be true }
+      it { expect(subject.show?).to be true }
+      it { expect(subject.close?).to be true }
+      it { expect(subject.load_truck?).to be true }
+      it { expect(subject.start?).to be true }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, delivery) }
+
+      it { expect(subject.index?).to be false }
+      it { expect(subject.show?).to be false }
+      it { expect(subject.close?).to be false }
+      it { expect(subject.load_truck?).to be false }
+      it { expect(subject.start?).to be false }
+    end
+  end
+end

--- a/spec/policies/shipment_policy_spec.rb
+++ b/spec/policies/shipment_policy_spec.rb
@@ -4,26 +4,26 @@ RSpec.describe ShipmentPolicy, type: :policy do
   let(:admin) { User.new(role: 'admin') }
   let(:driver) { User.new(role: 'driver') }
   let(:customer) { User.new(role: 'customer') }
-  
+
   # User from a company for testing company-specific permissions
-  let(:company_user) { 
+  let(:company_user) {
     user = User.new(role: 'driver')
     user.company_id = 1
     user
   }
-  
-  let(:company_shipment) { 
+
+  let(:company_shipment) {
     shipment = Shipment.new
     shipment.company_id = 1
     shipment
   }
-  
-  let(:other_company_shipment) { 
+
+  let(:other_company_shipment) {
     shipment = Shipment.new
     shipment.company_id = 2
     shipment
   }
-  
+
   let(:shipment) { Shipment.new } # Mock shipment object
 
   describe 'permissions' do
@@ -80,13 +80,13 @@ RSpec.describe ShipmentPolicy, type: :policy do
       it { expect(subject.assign_shipments_to_truck?).to be false }
       it { expect(subject.initiate_delivery?).to be false }
     end
-    
+
     context 'when the user belongs to the same company as the shipment' do
       let(:user) { company_user }
-      
+
       context 'with shipment from same company' do
         subject { described_class.new(user, company_shipment) }
-        
+
         it { expect(subject.index?).to be false }
         it { expect(subject.show?).to be true }
         it { expect(subject.new?).to be false }
@@ -100,10 +100,10 @@ RSpec.describe ShipmentPolicy, type: :policy do
         it { expect(subject.assign_shipments_to_truck?).to be true }
         it { expect(subject.initiate_delivery?).to be true }
       end
-      
+
       context 'with shipment from different company' do
         subject { described_class.new(user, other_company_shipment) }
-        
+
         it { expect(subject.edit?).to be false }
         it { expect(subject.update?).to be false }
       end

--- a/spec/policies/shipment_policy_spec.rb
+++ b/spec/policies/shipment_policy_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe ShipmentPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+  
+  # User from a company for testing company-specific permissions
+  let(:company_user) { 
+    user = User.new(role: 'driver')
+    user.company_id = 1
+    user
+  }
+  
+  let(:company_shipment) { 
+    shipment = Shipment.new
+    shipment.company_id = 1
+    shipment
+  }
+  
+  let(:other_company_shipment) { 
+    shipment = Shipment.new
+    shipment.company_id = 2
+    shipment
+  }
+  
+  let(:shipment) { Shipment.new } # Mock shipment object
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, shipment) }
+
+      it { expect(subject.index?).to be false }
+      it { expect(subject.show?).to be true }
+      it { expect(subject.new?).to be false }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.update?).to be true }
+      it { expect(subject.destroy?).to be false }
+      it { expect(subject.copy?).to be false }
+      it { expect(subject.close?).to be true }
+      it { expect(subject.assign?).to be true }
+      it { expect(subject.assign_shipments_to_truck?).to be true }
+      it { expect(subject.initiate_delivery?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, shipment) }
+
+      it { expect(subject.index?).to be false }
+      it { expect(subject.show?).to be true }
+      it { expect(subject.new?).to be false }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.update?).to be true }
+      it { expect(subject.destroy?).to be false }
+      it { expect(subject.copy?).to be false }
+      it { expect(subject.close?).to be true }
+      it { expect(subject.assign?).to be true }
+      it { expect(subject.assign_shipments_to_truck?).to be true }
+      it { expect(subject.initiate_delivery?).to be true }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, shipment) }
+
+      it { expect(subject.index?).to be true }
+      it { expect(subject.show?).to be true }
+      it { expect(subject.new?).to be true }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.create?).to be true }
+      it { expect(subject.update?).to be true }
+      it { expect(subject.destroy?).to be true }
+      it { expect(subject.copy?).to be true }
+      it { expect(subject.close?).to be false }
+      it { expect(subject.assign?).to be false }
+      it { expect(subject.assign_shipments_to_truck?).to be false }
+      it { expect(subject.initiate_delivery?).to be false }
+    end
+    
+    context 'when the user belongs to the same company as the shipment' do
+      let(:user) { company_user }
+      
+      context 'with shipment from same company' do
+        subject { described_class.new(user, company_shipment) }
+        
+        it { expect(subject.index?).to be false }
+        it { expect(subject.show?).to be true }
+        it { expect(subject.new?).to be false }
+        it { expect(subject.edit?).to be true }
+        it { expect(subject.create?).to be false }
+        it { expect(subject.update?).to be true }
+        it { expect(subject.destroy?).to be false }
+        it { expect(subject.copy?).to be false }
+        it { expect(subject.close?).to be true }
+        it { expect(subject.assign?).to be true }
+        it { expect(subject.assign_shipments_to_truck?).to be true }
+        it { expect(subject.initiate_delivery?).to be true }
+      end
+      
+      context 'with shipment from different company' do
+        subject { described_class.new(user, other_company_shipment) }
+        
+        it { expect(subject.edit?).to be false }
+        it { expect(subject.update?).to be false }
+      end
+    end
+  end
+end

--- a/spec/requests/deliveries_spec.rb
+++ b/spec/requests/deliveries_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "/deliveries", type: :request do
 
       it "renders the correct flash alert" do
         post close_delivery_url(delivery)
-        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+        expect(flash[:alert]).to eq("Not authorized.")
       end
     end
 

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -489,14 +489,14 @@ RSpec.describe "/shipments", type: :request do
       context "when the shipment is unclaimed" do
         let!(:shipment) { create(:shipment, user: valid_user, company: nil) }
 
-        it 'redirects to the deliveries page' do
+        it 'redirects to the root page' do
           get edit_shipment_url(shipment)
-          expect(response).to redirect_to(deliveries_path)
+          expect(response).to redirect_to(root_path)
         end
 
         it "shows an alert saying not authorized" do
           get edit_shipment_url(shipment)
-          expect(flash[:alert]).to eq("You are not authorized to modify this shipment.")
+          expect(flash[:alert]).to eq("You are not authorized to perform this action.")
         end
       end
 
@@ -576,7 +576,7 @@ RSpec.describe "/shipments", type: :request do
 
           it "shows an alert saying not authorized" do
             patch shipment_url(shipment), params: { shipment: new_attributes }
-            expect(flash[:alert]).to eq("You are not authorized to modify this shipment.")
+            expect(flash[:alert]).to eq("You are not authorized to perform this action.")
           end
 
           it "does not update the shipment" do
@@ -584,9 +584,9 @@ RSpec.describe "/shipments", type: :request do
             expect(shipment.name).not_to eq("Toys")
           end
 
-          it "redirects to the deliveries path" do
+          it "redirects to the root path" do
             patch shipment_url(shipment), params: { shipment: new_attributes }
-            expect(response).to redirect_to(deliveries_path)
+            expect(response).to redirect_to(root_path)
           end
         end
 
@@ -665,14 +665,14 @@ RSpec.describe "/shipments", type: :request do
             expect(shipment.name).not_to eq(nil)
           end
 
-          it 'redirects to the deliveries page' do
+          it 'redirects to the root page' do
             patch shipment_url(shipment), params: { shipment: invalid_attributes }
-            expect(response).to redirect_to(deliveries_path)
+            expect(response).to redirect_to(root_path)
           end
 
           it "shows an alert saying not authorized" do
             patch shipment_url(shipment), params: { shipment: invalid_attributes }
-            expect(flash[:alert]).to eq("You are not authorized to modify this shipment.")
+            expect(flash[:alert]).to eq("You are not authorized to perform this action.")
           end
         end
 


### PR DESCRIPTION
## Description
Authorization within certain actions was getting extraordinarily complex. Therefore, we pivoted to using pundit for access control. 

## Approach Taken
I added the pundit gem, and refactored the shipments and deliveries controllers to use the relevant policies.

## What Could Go Wrong?
This PR deals with updating user permissions. This is CRITICAL. Should this PR have mistakes in in, all user auth may break. Thorough testing is needed. Bug bash required.

## Remediation Strategy 
Rollback if necessary. THOROUGHLY test given this is critical functionality/ security related. At the slightest HINT of things going wrong, roll back.
