### PR TITLE
XMDEV-211: Adds pundit for remaining controllers. Replaces ensure_admin

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,8 +1,8 @@
 class AdminController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_admin
 
   def index
+    authorize :admin, :index?
     @drivers = User.for_company(current_company).drivers
     @shipment_statuses = ShipmentStatus.for_company(current_company)
     @trucks = Truck.for_company(current_company)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,10 +26,6 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    def ensure_admin
-      redirect_to(root_path, alert: "Not authorized.") unless current_user&.admin?
-    end
-
     def handle_record_not_found
       redirect_to(root_path, alert: "Not authorized.")
     end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,15 +1,15 @@
 class CompaniesController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_admin
   before_action :set_company, only: %i[edit update]
 
   def new
     @company = Company.new
+    authorize @company
   end
 
   def create
     @company = Company.new(company_params)
-
+    authorize @company
     if @company.save
       current_user.company = @company
       current_user.save
@@ -22,9 +22,12 @@ class CompaniesController < ApplicationController
     end
   end
 
-  def edit; end
+  def edit
+    authorize @company
+  end
 
   def update
+    authorize @company
     if @company.update(company_params)
       flash[:notice] = "Company updated successfully."
       redirect_to root_path

--- a/app/controllers/driver_managements_controller.rb
+++ b/app/controllers/driver_managements_controller.rb
@@ -1,14 +1,14 @@
 class DriverManagementsController < ApplicationController
     before_action :authenticate_user!
-    before_action :ensure_admin
-
     before_action :set_driver, only: %i[edit update]
 
     def new
+      authorize :driver_management, :new?
       @driver = User.new(role: "driver")
     end
 
     def create
+      authorize :driver_management, :create?
       @driver = User.new(driver_params)
       @driver.role = "driver"
       @driver.company = current_user.company
@@ -19,9 +19,12 @@ class DriverManagementsController < ApplicationController
       end
     end
 
-    def edit; end
+    def edit
+      authorize :driver_management, :edit?
+    end
 
     def update
+      authorize :driver_management, :update?
       if @driver.update(driver_params)
         redirect_to admin_index_path, notice: "Driver was successfully updated."
       else

--- a/app/controllers/shipment_action_preferences_controller.rb
+++ b/app/controllers/shipment_action_preferences_controller.rb
@@ -1,13 +1,14 @@
 class ShipmentActionPreferencesController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_admin
   before_action :set_preference
 
   def edit
+    authorize @preference
     @shipment_statuses = ShipmentStatus.for_company(current_company)
   end
 
   def update
+    authorize @preference
     if @preference.update(preference_params)
       redirect_to admin_index_path, notice: "Preference was successfully updated."
     else

--- a/app/controllers/shipment_statuses_controller.rb
+++ b/app/controllers/shipment_statuses_controller.rb
@@ -1,14 +1,15 @@
 class ShipmentStatusesController < ApplicationController
     before_action :authenticate_user!
-    before_action :ensure_admin
     before_action :set_shipment_status, only: %i[edit update destroy]
 
     def new
       @shipment_status = ShipmentStatus.new
+      authorize @shipment_status
     end
 
     def create
       @shipment_status = ShipmentStatus.new(shipment_status_params)
+      authorize @shipment_status
       if @shipment_status.save
         redirect_to admin_index_path, notice: "Shipment status was successfully created."
       else
@@ -16,9 +17,12 @@ class ShipmentStatusesController < ApplicationController
       end
     end
 
-    def edit; end
+    def edit
+      authorize @shipment_status
+    end
 
     def update
+      authorize @shipment_status
       if @shipment_status.update(shipment_status_params)
         redirect_to admin_index_path, notice: "Shipment status was successfully updated."
       else
@@ -27,6 +31,7 @@ class ShipmentStatusesController < ApplicationController
     end
 
     def destroy
+      authorize @shipment_status
       @shipment_status.destroy
       redirect_to admin_index_path, notice: "Shipment status was successfully destroyed."
     end

--- a/app/controllers/trucks_controller.rb
+++ b/app/controllers/trucks_controller.rb
@@ -1,24 +1,27 @@
 class TrucksController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_admin
   before_action :set_truck, only: %i[ show edit update destroy ]
 
   # GET /trucks/1
   def show
+    authorize @truck
   end
 
   # GET /trucks/new
   def new
     @truck = Truck.new
+    authorize @truck
   end
 
   # GET /trucks/1/edit
   def edit
+    authorize @truck
   end
 
   # POST /trucks
   def create
     @truck = Truck.new(truck_params)
+    authorize @truck
 
     if @truck.save
       redirect_to admin_index_path, notice: "Truck was successfully created."
@@ -29,6 +32,7 @@ class TrucksController < ApplicationController
 
   # PATCH/PUT /trucks/1
   def update
+    authorize @truck
     if @truck.update(truck_params)
       redirect_to admin_index_path, notice: "Truck was successfully updated."
     else
@@ -38,12 +42,12 @@ class TrucksController < ApplicationController
 
   # DELETE /trucks/1
   def destroy
+    authorize @truck
     @truck.destroy!
     redirect_to admin_index_path, status: :see_other, notice: "Truck was successfully destroyed."
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_truck
       @truck = Truck.for_company(current_company).find(params.expect(:id))
     end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,0 +1,11 @@
+class AdminPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  def index?
+    user.admin?
+  end
+end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -1,0 +1,30 @@
+class CompanyPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  attr_reader :user, :company
+
+  def initialize(user, company)
+    @user = user
+    @company = company
+  end
+
+  def new?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def edit?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/driver_management_policy.rb
+++ b/app/policies/driver_management_policy.rb
@@ -1,0 +1,23 @@
+class DriverManagementPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  def new?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def edit?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/shipment_action_preference_policy.rb
+++ b/app/policies/shipment_action_preference_policy.rb
@@ -1,0 +1,22 @@
+class ShipmentActionPreferencePolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  attr_reader :user, :preference
+
+  def initialize(user, preference)
+    @user = user
+    @preference = preference
+  end
+
+  def edit?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/shipment_status_policy.rb
+++ b/app/policies/shipment_status_policy.rb
@@ -1,0 +1,34 @@
+class ShipmentStatusPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  attr_reader :user, :status
+
+  def initialize(user, status)
+    @user = user
+    @status = status
+  end
+
+  def new?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def edit?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+end

--- a/app/policies/truck_policy.rb
+++ b/app/policies/truck_policy.rb
@@ -1,0 +1,38 @@
+class TruckPolicy < ApplicationPolicy
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  attr_reader :user, :truck
+
+  def initialize(user, truck)
+    @user = user
+    @truck = truck
+  end
+
+  def show?
+    user.admin?
+  end
+
+  def new?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def edit?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+end

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe AdminPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, nil) }
+
+      it { expect(subject.index?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, nil) }
+
+      it { expect(subject.index?).to be false }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, nil) }
+
+      it { expect(subject.index?).to be false }
+    end
+  end
+end

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CompanyPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  let(:company) { Company.new } # Mock shipment object
+
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, company) }
+
+      it { expect(subject.new?).to be true }
+      it { expect(subject.create?).to be true }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.update?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, company) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.update?).to be false }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, company) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.update?).to be false }
+    end
+  end
+end

--- a/spec/policies/driver_management_policy_spec.rb
+++ b/spec/policies/driver_management_policy_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe DriverManagementPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, nil) }
+
+      it { expect(subject.new?).to be true }
+      it { expect(subject.create?).to be true }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.update?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, nil) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.update?).to be false }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, nil) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.update?).to be false }
+    end
+  end
+end

--- a/spec/policies/shipment_action_preference_policy_spec.rb
+++ b/spec/policies/shipment_action_preference_policy_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ShipmentActionPreferencePolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  let(:preference) { ShipmentActionPreference.new }
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, preference) }
+
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.update?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, preference) }
+
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.update?).to be false }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, preference) }
+
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.update?).to be false }
+    end
+  end
+end

--- a/spec/policies/shipment_status_policy_spec.rb
+++ b/spec/policies/shipment_status_policy_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ShipmentStatusPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  let(:status) { ShipmentStatus.new } # Mock shipment object
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, status) }
+
+      it { expect(subject.new?).to be true }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.create?).to be true }
+      it { expect(subject.update?).to be true }
+      it { expect(subject.destroy?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, status) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.update?).to be false }
+      it { expect(subject.destroy?).to be false }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, status) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.update?).to be false }
+      it { expect(subject.destroy?).to be false }
+    end
+  end
+end

--- a/spec/policies/truck_policy_spec.rb
+++ b/spec/policies/truck_policy_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe TruckPolicy, type: :policy do
+  let(:admin) { User.new(role: 'admin') }
+  let(:driver) { User.new(role: 'driver') }
+  let(:customer) { User.new(role: 'customer') }
+
+  let(:truck) { Truck.new } # Mock shipment object
+
+  describe 'permissions' do
+    context 'when the user is an admin' do
+      let(:user) { admin }
+      subject { described_class.new(user, truck) }
+
+      it { expect(subject.show?).to be true }
+      it { expect(subject.new?).to be true }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.create?).to be true }
+      it { expect(subject.update?).to be true }
+      it { expect(subject.destroy?).to be true }
+    end
+
+    context 'when the user is a driver' do
+      let(:user) { driver }
+      subject { described_class.new(user, truck) }
+
+      it { expect(subject.show?).to be false }
+      it { expect(subject.new?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.update?).to be false }
+      it { expect(subject.destroy?).to be false }
+    end
+
+    context 'when the user is a customer' do
+      let(:user) { customer }
+      subject { described_class.new(user, truck) }
+
+      it { expect(subject.show?).to be false }
+      it { expect(subject.new?).to be false }
+      it { expect(subject.edit?).to be false }
+      it { expect(subject.create?).to be false }
+      it { expect(subject.update?).to be false }
+      it { expect(subject.destroy?).to be false }
+    end
+  end
+end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "/admin", type: :request do
 
       it "renders an error message" do
         get admin_index_path
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
   end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "/companies", type: :request do
 
       it 'renders with an error message' do
         get new_company_url
-        expect(flash[:alert]).to eq('Not authorized.')
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
       end
     end
 
@@ -226,7 +226,7 @@ RSpec.describe "/companies", type: :request do
 
       it 'renders with an error message' do
         post companies_url, params: { company: valid_attributes }
-        expect(flash[:alert]).to eq('Not authorized.')
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
       end
     end
 
@@ -240,7 +240,7 @@ RSpec.describe "/companies", type: :request do
 
       it 'renders with an error message' do
         get edit_company_url(company)
-        expect(flash[:alert]).to eq('Not authorized.')
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
       end
     end
 
@@ -264,7 +264,7 @@ RSpec.describe "/companies", type: :request do
 
       it 'renders with an error message' do
         patch company_url(company), params: { company: new_attributes }
-        expect(flash[:alert]).to eq('Not authorized.')
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
       end
     end
   end

--- a/spec/requests/driver_management_spec.rb
+++ b/spec/requests/driver_management_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "/driver_managements", type: :request do
 
       it "renders the correct flash alert" do
         get new_driver_management_url
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -200,7 +200,7 @@ RSpec.describe "/driver_managements", type: :request do
 
       it "renders the correct flash alert" do
         post driver_managements_url, params: { user: valid_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -212,7 +212,7 @@ RSpec.describe "/driver_managements", type: :request do
 
       it "renders the correct flash alert" do
         get edit_driver_management_url(driver)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -230,7 +230,7 @@ RSpec.describe "/driver_managements", type: :request do
 
       it "renders the correct flash alert" do
         patch driver_management_url(driver), params: { user: new_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
   end

--- a/spec/requests/shipment_action_preferences_spec.rb
+++ b/spec/requests/shipment_action_preferences_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "/shipment_action_preferences", type: :request do
 
       it "renders the correct flash alert" do
         get edit_shipment_action_preference_url(company_preference)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe "/shipment_action_preferences", type: :request do
 
       it "renders the correct flash alert" do
         patch shipment_action_preference_url(company_preference), params: { shipment_action_preference: new_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
   end

--- a/spec/requests/shipment_statuses_spec.rb
+++ b/spec/requests/shipment_statuses_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe "/shipment_statuses", type: :request do
 
       it "renders the correct flash alert" do
         get new_shipment_status_url
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -195,7 +195,7 @@ RSpec.describe "/shipment_statuses", type: :request do
 
       it "renders the correct flash alert" do
         get edit_shipment_status_url(shipment_status)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -213,7 +213,7 @@ RSpec.describe "/shipment_statuses", type: :request do
 
       it "renders the correct flash alert" do
         post shipment_statuses_url, params: { shipment_status: valid_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -231,7 +231,7 @@ RSpec.describe "/shipment_statuses", type: :request do
 
       it "renders the correct flash alert" do
         patch shipment_status_url(shipment_status), params: { shipment_status: new_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -249,7 +249,7 @@ RSpec.describe "/shipment_statuses", type: :request do
 
       it "renders the correct flash alert" do
         delete shipment_status_url(shipment_status)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
   end

--- a/spec/requests/trucks_spec.rb
+++ b/spec/requests/trucks_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "/trucks", type: :request do
 
       it "renders the correct flash alert" do
         get truck_url(truck)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -244,7 +244,7 @@ RSpec.describe "/trucks", type: :request do
 
       it "renders the correct flash alert" do
         get new_truck_url
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -256,7 +256,7 @@ RSpec.describe "/trucks", type: :request do
 
       it "renders the correct flash alert" do
         get truck_url(truck)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -274,7 +274,7 @@ RSpec.describe "/trucks", type: :request do
 
       it "renders the correct flash alert" do
         post trucks_url, params: { truck: valid_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -292,7 +292,7 @@ RSpec.describe "/trucks", type: :request do
 
       it "renders the correct flash alert" do
         patch truck_url(truck), params: { truck: new_attributes }
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
 
@@ -310,7 +310,7 @@ RSpec.describe "/trucks", type: :request do
 
       it "renders the correct flash alert" do
         delete truck_url(truck)
-        expect(flash[:alert]).to eq("Not authorized.")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
   end


### PR DESCRIPTION
## Description
Authorization within certain actions was getting extraordinarily complex. Therefore, we pivoted to using pundit for access control. This PR updates the remaining controllers to leverage pundit policies (refactors ensure_action callback)

## Approach Taken
Refactored the relevant controllers and created the associated pundit policies in order to achieve the same functionality.

## What Could Go Wrong?
This PR deals with updating user permissions. This is CRITICAL. Should this PR have mistakes in in, all user auth may break. Thorough testing is needed. Bug bash required.

## Remediation Strategy 
Rollback if necessary. THOROUGHLY test given this is critical functionality/ security related. At the slightest HINT of things going wrong, roll back.
