### PR TITLE
XMDEV-217: Fixes missing CSS on driver edit page

### DIFF
--- a/app/views/driver_managements/_form.html.erb
+++ b/app/views/driver_managements/_form.html.erb
@@ -1,41 +1,41 @@
 <%= form_with model: @driver, url: driver_management_path, local: true, class: 'styled-form' do |f| %>
-  <% if @driver.errors.any? %>
-    <div class="error-messages">
-      <h2><%= pluralize(@driver.errors.count, "error") %> prohibited this driver from being saved:</h2>
-      <ul>
-        <% @driver.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<% if @driver.errors.any? %>
+<div class="error-messages">
+  <h2><%= pluralize(@driver.errors.count, "error") %> prohibited this driver from being saved:</h2>
+  <ul>
+    <% @driver.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>
 
-  <div class="form-group">
-    <%= f.label :first_name, "First Name", class: 'form-label' %>
-    <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
-  </div>
+<div class="form-group">
+  <%= f.label :first_name, "First Name", class: 'form-label' %>
+  <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
+</div>
 
-  <div class="form-group">
-    <%= f.label :last_name, "Last Name", class: 'form-label' %>
-    <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
-  </div>
+<div class="form-group">
+  <%= f.label :last_name, "Last Name", class: 'form-label' %>
+  <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
+</div>
 
-  <div class="form-group">
-    <%= f.label :home_address, class: 'form-label'  %>
-    <%= f.text_field :home_address, class: "form-control" %>
-  </div>
+<div class="form-group">
+  <%= f.label :home_address, class: 'form-label'  %>
+  <%= f.text_field :home_address, class: "form-input" %>
+</div>
 
-  <div class="form-group">
-    <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
-    <%= f.text_field :drivers_license, class: 'form-input' %>
-  </div>
+<div class="form-group">
+  <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
+  <%= f.text_field :drivers_license, class: 'form-input' %>
+</div>
 
-  <div class="form-group">
-    <%= f.label :email, nil, class: 'form-label' %>
-    <%= f.email_field :email, class: 'form-input', required: true %>
-  </div>
+<div class="form-group">
+  <%= f.label :email, nil, class: 'form-label' %>
+  <%= f.email_field :email, class: 'form-input', required: true %>
+</div>
 
-  <div class="actions">
-    <%= f.submit "Save", class: 'button primary-button' %>
-  </div>
+<div class="actions">
+  <%= f.submit "Save", class: 'button primary-button' %>
+</div>
 <% end %>


### PR DESCRIPTION
## Description
There was an issue with the form field in the driver edit page. The Home Address field didn't have the correct css styling.

## Approach Taken
Update the css class for the form field.

## What Could Go Wrong?
Purely a cosmetic change with a tried and true CSS class. Effectively zero risk.

## Remediation Strategy 
NA
