### PR TITLE
XMDEV-190: Ensures all relationships are correct considering deletion

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,9 +1,10 @@
 class Company < ApplicationRecord
-  has_many :users, dependent: :nullify
-  has_many :shipments
-  has_many :shipment_statuses
-  has_many :trucks
-  has_many :shipment_action_preferences
+  has_many :shipments, dependent: :nullify
+
+  has_many :users, dependent: :destroy
+  has_many :shipment_statuses, dependent: :destroy
+  has_many :trucks, dependent: :destroy
+  has_many :shipment_action_preferences, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :address, presence: true

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -2,7 +2,7 @@ class Delivery < ApplicationRecord
   belongs_to :user
   belongs_to :truck
 
-  has_many :delivery_shipments
+  has_many :delivery_shipments, dependent: :nullify
   has_many :shipments, through: :delivery_shipments
 
   enum :status, {

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -4,7 +4,7 @@ class Shipment < ApplicationRecord
   belongs_to :truck, optional: true
   belongs_to :shipment_status, optional: true
 
-  has_many :delivery_shipments
+  has_many :delivery_shipments, dependent: :nullify
   has_many :deliveries, through: :delivery_shipments
 
   validates :name, :sender_name, :sender_address, :receiver_name, :receiver_address, :weight, :length, :width, :height, presence: true

--- a/app/models/shipment_status.rb
+++ b/app/models/shipment_status.rb
@@ -1,7 +1,7 @@
 class ShipmentStatus < ApplicationRecord
   belongs_to :company
 
-  has_many :shipments, dependent: :destroy
+  has_many :shipments, dependent: :nullify
   has_many :shipment_action_preferences, dependent: :nullify
 
   validates :name, presence: true

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -2,7 +2,7 @@ class Truck < ApplicationRecord
   belongs_to :company
 
   has_many :shipments, dependent: :nullify
-  has_many :deliveries, dependent: :destroy
+  has_many :deliveries, dependent: :nullify
 
   validates :make, :model, :weight, :length, :width, :height, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   belongs_to :company, optional: true
 
   has_many :shipments, dependent: :nullify
-  has_many :deliveries
+  has_many :deliveries, dependent: :nullify
 
   # Validations
   validates :first_name, presence: true, length: { maximum: 50 }

--- a/app/policies/truck_policy.rb
+++ b/app/policies/truck_policy.rb
@@ -33,6 +33,6 @@ class TruckPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user.admin?
+    user.admin? && truck.active_delivery.nil?
   end
 end

--- a/app/views/deliveries/start.html.erb
+++ b/app/views/deliveries/start.html.erb
@@ -2,7 +2,7 @@
 
 <h2>My active delivery</h2>
 <% if @active_delivery %>
-<h4>Truck: <%= @active_delivery.truck.display_name %></h4>
+<h4>Truck: <%= @active_delivery.truck&.display_name %></h4>
 <h4>Shipments: <%= @active_delivery.shipments.count %></h4>
 <p>
   <%= link_to "View Delivery", delivery_path(@active_delivery), class: "btn btn-primary" %>

--- a/db/migrate/20250316161838_make_truck_and_user_optional_in_deliveries.rb
+++ b/db/migrate/20250316161838_make_truck_and_user_optional_in_deliveries.rb
@@ -1,0 +1,19 @@
+class MakeTruckAndUserOptionalInDeliveries < ActiveRecord::Migration[8.0]
+  def change
+    if column_exists?(:deliveries, :truck_id) && !column_nullable?(:deliveries, :truck_id)
+      change_column_null :deliveries, :truck_id, true
+    end
+
+    if column_exists?(:deliveries, :user_id) && !column_nullable?(:deliveries, :user_id)
+      change_column_null :deliveries, :user_id, true
+    end
+  end
+
+  private
+
+  def column_nullable?(table, column)
+    connection = ActiveRecord::Base.connection
+    column_info = connection.columns(table).find { |c| c.name == column.to_s }
+    column_info.null
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_09_045158) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_16_161838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,8 +22,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_09_045158) do
   end
 
   create_table "deliveries", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "truck_id", null: false
+    t.bigint "user_id"
+    t.bigint "truck_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Company, type: :model do
-  it { should have_many(:users).dependent(:nullify) }
-  it { should have_many(:shipments) }
-  it { should have_many(:shipment_statuses) }
-  it { should have_many(:trucks) }
-  it { should have_many(:shipment_action_preferences) }
+  it { should have_many(:shipments).dependent(:nullify) }
+
+  it { should have_many(:users).dependent(:destroy) }
+  it { should have_many(:shipment_statuses).dependent(:destroy) }
+  it { should have_many(:trucks).dependent(:destroy) }
+  it { should have_many(:shipment_action_preferences).dependent(:destroy) }
 
 
   it { should validate_presence_of(:name) }

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Delivery, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:truck) }
-    it { is_expected.to have_many(:delivery_shipments) }
+    it { is_expected.to have_many(:delivery_shipments).dependent(:nullify) }
     it { is_expected.to have_many(:shipments).through(:delivery_shipments) }
   end
 

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Shipment, type: :model do
     it { is_expected.to belong_to(:user).optional }
     it { is_expected.to belong_to(:shipment_status).optional }
     it { is_expected.to belong_to(:company).optional }
-    it { is_expected.to have_many(:delivery_shipments) }
+    it { is_expected.to have_many(:delivery_shipments).dependent(:nullify) }
     it { is_expected.to have_many(:deliveries).through(:delivery_shipments) }
   end
 

--- a/spec/models/shipment_status_spec.rb
+++ b/spec/models/shipment_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ShipmentStatus, type: :model do
 
   ## Association Tests
   describe "associations" do
-    it { is_expected.to have_many(:shipments).dependent(:destroy) }
+    it { is_expected.to have_many(:shipments).dependent(:nullify) }
     it { is_expected.to belong_to(:company) }
     it { should have_many(:shipment_action_preferences).dependent(:nullify) }
   end
@@ -39,12 +39,18 @@ RSpec.describe ShipmentStatus, type: :model do
     end
   end
 
-  ## Dependent Destroy Tests
-  describe "dependent destroy" do
+  ## Dependent Nullify Tests
+  describe "dependent nullify" do
     let!(:shipment) { create(:shipment, shipment_status_id: shipment_status.id, company: company) }
 
-    it "destroys associated shipments when destroyed" do
-      expect { shipment_status.destroy }.to change(Shipment, :count).by(-1)
+    it "does not destroy associated shipments when destroyed" do
+      expect { shipment_status.destroy }.to change(Shipment, :count).by(0)
+    end
+
+    it "nullifies the column in the shipment" do
+      shipment_status.destroy
+      shipment.reload
+      expect(shipment.shipment_status_id).to be_nil
     end
   end
 

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Truck, type: :model do
   ## Association Tests
   describe "associations" do
     it { is_expected.to have_many(:shipments) }
-    it { is_expected.to have_many(:deliveries).dependent(:destroy) }
+    it { is_expected.to have_many(:deliveries).dependent(:nullify) }
     it { is_expected.to belong_to(:company) }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User, type: :model do
   ## Association Tests
   describe "associations" do
     it { is_expected.to have_many(:shipments) }
-    it { is_expected.to have_many(:deliveries) }
+    it { is_expected.to have_many(:deliveries).dependent(:nullify) }
     it { should belong_to(:company).optional }
   end
 


### PR DESCRIPTION
## Description
This change updates all relationships so that if a record is deleted, the related records and updated correct to prevent rails referencing errors.

## Approach Taken
Update the `dependent` flags for has_many relationships.

## What Could Go Wrong?
This deals with the associated deletions/updates when records are deleted. As such, if I missed any relationships (foreign keys) rails will complain.

## Remediation Strategy 
If errors arise, rollback.
