### PR TITLE
XMDEV-221: Adds truck id to forms (optionally)

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -5,6 +5,7 @@ class Company < ApplicationRecord
   has_many :shipment_statuses, dependent: :destroy
   has_many :trucks, dependent: :destroy
   has_many :shipment_action_preferences, dependent: :destroy
+  has_many :forms, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :address, presence: true

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,6 +1,7 @@
 class Form < ApplicationRecord
   belongs_to :user
   belongs_to :company
+  belongs_to :truck, optional: true
 
   # Common Validations
   validates :user_id, presence: true

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -3,6 +3,7 @@ class Truck < ApplicationRecord
 
   has_many :shipments, dependent: :nullify
   has_many :deliveries, dependent: :nullify
+  has_many :forms, dependent: :nullify
 
   validates :make, :model, :weight, :length, :width, :height, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
 
   has_many :shipments, dependent: :nullify
   has_many :deliveries, dependent: :nullify
+  has_many :forms, dependent: :nullify
 
   # Validations
   validates :first_name, presence: true, length: { maximum: 50 }

--- a/app/views/trucks/_form.html.erb
+++ b/app/views/trucks/_form.html.erb
@@ -53,7 +53,7 @@
 </div>
 
 <div class="form-group">
-  <%= form.label :width, "Width of Bed(cm)", class: 'form-label' %>
+  <%= form.label :width, "Width of Bed (cm)", class: 'form-label' %>
   <%= form.text_field :width, class: 'form-input' %>
 </div>
 

--- a/db/migrate/20250321021738_add_truck_to_forms.rb
+++ b/db/migrate/20250321021738_add_truck_to_forms.rb
@@ -1,0 +1,7 @@
+class AddTruckToForms < ActiveRecord::Migration[8.0]
+  def change
+    unless column_exists?(:forms, :truck_id)
+      add_reference :forms, :truck, foreign_key: true, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_20_020038) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_21_021738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,7 +50,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_20_020038) do
     t.datetime "submitted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "truck_id"
     t.index ["company_id"], name: "index_forms_on_company_id"
+    t.index ["truck_id"], name: "index_forms_on_truck_id"
     t.index ["user_id"], name: "index_forms_on_user_id"
   end
 
@@ -139,6 +141,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_20_020038) do
   add_foreign_key "delivery_shipments", "deliveries"
   add_foreign_key "delivery_shipments", "shipments"
   add_foreign_key "forms", "companies"
+  add_foreign_key "forms", "trucks"
   add_foreign_key "forms", "users"
   add_foreign_key "shipment_action_preferences", "companies"
   add_foreign_key "shipment_action_preferences", "shipment_statuses"

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Company, type: :model do
   it { should have_many(:shipment_statuses).dependent(:destroy) }
   it { should have_many(:trucks).dependent(:destroy) }
   it { should have_many(:shipment_action_preferences).dependent(:destroy) }
-
+  it { should have_many(:forms).dependent(:destroy) }
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:address) }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Form, type: :model do
   describe "associations" do
     it { should belong_to(:user) }
     it { should belong_to(:company) }
+    it { should belong_to(:truck).optional }
   end
 
   describe "validations" do

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Truck, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:shipments) }
     it { is_expected.to have_many(:deliveries).dependent(:nullify) }
+    it { is_expected.to have_many(:forms).dependent(:nullify) }
     it { is_expected.to belong_to(:company) }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe User, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:shipments) }
     it { is_expected.to have_many(:deliveries).dependent(:nullify) }
+    it { is_expected.to have_many(:forms).dependent(:nullify) }
     it { should belong_to(:company).optional }
   end
 


### PR DESCRIPTION
## Description
The forms object needs to be linked to a truck for maintenance work. This PR adds this optional 

## Approach Taken
Migration and updates the models.

## What Could Go Wrong?
Nothing major. Just adds associations.

## Remediation Strategy 
Rollback if needed.
