### PR TITLE
XMDEV-220: Adds pre-delivery inspection form on delivery start

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,6 +15,7 @@ class Form < ApplicationRecord
 
   # Define expected fields for each form type
   FORM_TEMPLATES = {
+    "Pre-delivery Inspection" => %w[start_time],
     "Delivery" => %w[destination start_time items],
     "Maintenance" => %w[mileage oil_changed tire_pressure_checked notes],
     "Hazmat" => %w[shipment_id hazardous_materials inspection_passed]

--- a/app/services/initiate_delivery.rb
+++ b/app/services/initiate_delivery.rb
@@ -12,6 +12,7 @@ class InitiateDelivery < ApplicationService
     success = false
 
     ActiveRecord::Base.transaction do
+      create_delivery_form
       create_delivery
       open_shipments = find_open_shipments
 
@@ -29,6 +30,22 @@ class InitiateDelivery < ApplicationService
   end
 
   private
+
+  def create_delivery_form
+    @form = Form.create!({
+      user_id: @current_user.id,
+      company_id: @current_company.id,
+      truck_id: @truck_id,
+      title: "Pre Delivery Inspection",
+      form_type: "Pre-delivery Inspection",
+      content: {
+        start_time: Time.now
+      }
+    })
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << "Failed to create Pre delivery inspection form: #{e.message}"
+    raise ActiveRecord::Rollback
+  end
 
   def create_delivery
     @delivery = Delivery.create!({

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -4,12 +4,15 @@ erDiagram
     Companies ||--o{ Shipments : manages
     Companies ||--o{ ShipmentStatuses : defines
     Companies ||--o{ ShipmentActionPreferences : configures
+    Companies ||--o{ Forms : owns
     
     Users ||--o{ Deliveries : performs
     Users ||--o{ Shipments : handles
+    Users ||--o{ Forms : submits
     
     Trucks ||--o{ Deliveries : assigned_to
     Trucks ||--o{ Shipments : carries
+    Trucks ||--o{ Forms : relates_to
     
     Shipments }o--|| ShipmentStatuses : has_status
     
@@ -111,6 +114,19 @@ erDiagram
         string action
         bigint company_id FK
         bigint shipment_status_id FK
+        datetime created_at
+        datetime updated_at
+    }
+    
+    Forms {
+        bigint id PK
+        bigint user_id FK
+        bigint company_id FK
+        bigint truck_id FK
+        string title
+        string form_type
+        jsonb content
+        datetime submitted_at
         datetime created_at
         datetime updated_at
     }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -121,6 +121,27 @@ RSpec.describe Form, type: :model do
       end
     end
 
+    context "with Pre-delivery Inspection form type" do
+      let(:form) do
+        Form.new(valid_attributes.merge(
+          form_type: "Pre-delivery Inspection",
+          content: {
+            start_time: ""
+          }
+        ))
+      end
+
+      it "is valid with all required fields" do
+        expect(form).to be_valid
+      end
+
+      it "is invalid when missing required fields" do
+        form.content = form.content.except("start_time")
+        expect(form).not_to be_valid
+        expect(form.errors[:content]).to include("is missing required fields: start_time")
+      end
+    end
+
     context "with unknown form type" do
       let(:form) do
         Form.new(valid_attributes.merge(

--- a/spec/services/initiate_delivery_spec.rb
+++ b/spec/services/initiate_delivery_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe InitiateDelivery, type: :service do
         expect { subject.run }.to change(Delivery, :count).by(1)
       end
 
+      it "creates a form" do
+        expect { subject.run }.to change(Form, :count).by(1)
+      end
+
       it "associates shipments with the delivery" do
         subject.run
         expect(subject.delivery.shipments).to match_array([ shipment1, shipment2 ])


### PR DESCRIPTION
## Description
This PR adds the creation of a form when the shipment is initiated.

## Approach Taken
Solely a backend change. Cosmetic front end changes will subsequently come.

## What Could Go Wrong?
Nothing major, just movin' data and fitting into already established patterns.

## Remediation Strategy 
NA
