### PR TITLE
XMDEV-227: Fixes issues with flaky tests due to name validation error

### DIFF
--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :company do
-    name { Faker::Company.name }
+    name { "#{Faker::Company.name} #{SecureRandom.uuid}" }
     address { Faker::Address.full_address }
   end
 end

--- a/spec/factories/shipment_statuses.rb
+++ b/spec/factories/shipment_statuses.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :shipment_status do
-    name { Faker::Commerce.product_name }
+    name { "#{Faker::Commerce.product_name} #{SecureRandom.uuid}" }
     locked_for_customers { false }
     association :company
   end

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :shipment do
-    name { Faker::Commerce.product_name }
+    name { "#{Faker::Commerce.product_name} #{SecureRandom.uuid}" }
     sender_name { Faker::Name.name }
     sender_address { Faker::Address.full_address }
     receiver_name { Faker::Name.name }

--- a/spec/factories/trucks.rb
+++ b/spec/factories/trucks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :truck do
-    make { Faker::Vehicle.manufacture }
+    make { "#{Faker::Vehicle.manufacture} #{SecureRandom.uuid}" }
     model { Faker::Vehicle.model }
     year { Faker::Vehicle.year }
     mileage { Faker::Number.between(from: 10_000, to: 500_000) }


### PR DESCRIPTION
## Description
We constantly have tests flake due to name validation errors since we use Faker. This PR adds a UUID to the generated names to guarantee uniqueness so tests won't flake.

## Approach Taken
I added a UUID to the attributes that were causing issues. This confirms they'd be unique when CI is running, and thus the error wouldn't happen.

## What Could Go Wrong?
This is a bug fix, things are already going wrong and we're fixing things.

## Remediation Strategy 
Do not rollback. This fixes one of the most annoying issues. WE ONLY GO FORWARD 🤘 
