### PR TITLE
XMDEV-228: Adds missing specs for scopes in each model

### DIFF
--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -33,11 +33,14 @@ RSpec.describe Delivery, type: :model do
 
   ## Scope Tests
   describe "scopes" do
+    let!(:user) { create(:user) }
+    let!(:other_user) { create(:user) }
+
     before do
-      @scheduled_delivery = create(:delivery, status: :scheduled)
-      @in_progress_delivery = create(:delivery, status: :in_progress)
-      @completed_delivery = create(:delivery, status: :completed)
-      @cancelled_delivery = create(:delivery, status: :cancelled)
+      @scheduled_delivery = create(:delivery, status: :scheduled, user: user)
+      @in_progress_delivery = create(:delivery, status: :in_progress, user: other_user)
+      @completed_delivery = create(:delivery, status: :completed, user: user)
+      @cancelled_delivery = create(:delivery, status: :cancelled, user: other_user)
     end
 
     describe ".active" do
@@ -51,6 +54,13 @@ RSpec.describe Delivery, type: :model do
       it "includes completed and cancelled deliveries" do
         expect(Delivery.inactive).to include(@completed_delivery, @cancelled_delivery)
         expect(Delivery.inactive).not_to include(@scheduled_delivery, @in_progress_delivery)
+      end
+    end
+
+    describe ".for_user" do
+      it "includes trucks that belong to the company" do
+        expect(Delivery.for_user(user)).to include(@scheduled_delivery, @completed_delivery)
+        expect(Delivery.for_user(user)).not_to include(@in_progress_delivery, @cancelled_delivery)
       end
     end
   end

--- a/spec/models/shipment_action_preference_spec.rb
+++ b/spec/models/shipment_action_preference_spec.rb
@@ -61,6 +61,22 @@ RSpec.describe ShipmentActionPreference, type: :model do
     end
   end
 
+  ## Scope Tests
+  describe "scopes" do
+    let!(:company) { create(:company) }
+    let!(:other_company) { create(:company) }
+
+    let!(:pref) { create(:shipment_action_preference, company: company) }
+    let!(:other_pref) { create(:shipment_action_preference, company: other_company) }
+
+    describe ".for_company" do
+      it "includes trucks that belong to the company" do
+        expect(ShipmentActionPreference.for_company(company)).to include(pref)
+        expect(ShipmentActionPreference.for_company(company)).not_to include(other_pref)
+      end
+    end
+  end
+
   describe "constants" do
     it "defines the expected ACTIONS" do
       expected_actions = [

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe Shipment, type: :model do
   end
 
   ## Scope Tests
+  describe "scopes" do
+    let!(:user) { create(:user) }
+    let!(:company) { create(:company) }
+    let!(:shipment) { create(:shipment, company: company, user: user) }
+    let!(:other_shipment) { create(:shipment, company: nil, user: nil) }
+
+    describe ".for_company" do
+      it "includes shipments that belong to the company" do
+        expect(Shipment.for_company(company)).to include(shipment)
+        expect(Shipment.for_company(company)).not_to include(other_shipment)
+      end
+    end
+
+    describe ".for_user" do
+      it "includes shipments that belong to the user" do
+        expect(Shipment.for_user(user)).to include(shipment)
+        expect(Shipment.for_user(user)).not_to include(other_shipment)
+      end
+    end
+  end
 
 
   ## Edge Case Tests

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -90,6 +90,22 @@ RSpec.describe Truck, type: :model do
     end
   end
 
+  ## Scope Tests
+  describe "scopes" do
+    let!(:company) { create(:company) }
+    let!(:other_company) { create(:company) }
+
+    let!(:truck) { create(:truck, company: company) }
+    let!(:other_truck) { create(:truck, company: other_company) }
+
+    describe ".for_company" do
+      it "includes trucks that belong to the company" do
+        expect(Truck.for_company(company)).to include(truck)
+        expect(Truck.for_company(company)).not_to include(other_truck)
+      end
+    end
+  end
+
   ## Custom Method Tests
   describe "#display_name" do
     it "returns a string formatted as make-model-year" do


### PR DESCRIPTION
## Description
This PR adds new specs for scopes that weren't previously being tested.

## Approach Taken
Adds specs for the scopes. Standard test development with rspec.

## What Could Go Wrong?
Nothing major. Adds specs. No user facing changes.

## Remediation Strategy 
Zero risk PR. No rollback needed. Adds specs.
