### PR TITLE
XMDEV-226: Fixes issue with Mark Complete button showing for already closed shipments

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -164,10 +164,22 @@ button, .primary-button, .secondary-button, .danger-button {
   border-radius: 5px;
 }
 
+.form-select {
+  width: auto; /* Adjust width as needed */
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+}
+
 .form-input:focus {
   border-color: #09e80d;
   outline: none;
   box-shadow: 0 0 5px rgba(9, 232, 13, 0.5);
+}
+
+.form-select option {
+  white-space: normal; 
+  overflow: visible;
 }
 
 /* Messages */

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -25,7 +25,7 @@ class Delivery < ApplicationRecord
   end
 
   def can_be_closed?
-    shipments.all? { |shipment| !shipment.open? }
+    shipments.all? { |shipment| !shipment.open? } && active?
   end
 
   def volume

--- a/app/views/deliveries/load_truck.html.erb
+++ b/app/views/deliveries/load_truck.html.erb
@@ -6,7 +6,9 @@
 
 <div class="form-group">
   <%= f.label :truck_id, 'Truck', class: 'form-label' %>
-  <%= f.collection_select :truck_id, @trucks ||= [], :id, :display_name, { prompt: "Please select a truck" }, { class: 'form-input' } %>
+  <%= f.collection_select :truck_id, @trucks, :id, ->(truck) { truck.display_name.to_s }, 
+  { prompt: "Please select a truck" }, 
+  { class: 'form-select', title: "Choose a truck" } %>
 </div>
 
 <table class="styled-table">

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -1,3 +1,16 @@
+<% if !@delivery.active? %>
+<% if @delivery.completed? %>
+<div class="notice">
+  Delivery is complete. No further edits are possible
+</div>
+<% else %>
+<div class="alert">
+  Delivery has been cancelled. No further edits are possible
+</div>
+<% end %>
+<% end %>
+</div>
+<br />
 <div data-controller="show-pre-delivery">
   <div class="page-header">
     <h1 class="page-title">Delivery Details</h1>

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -93,14 +93,10 @@ RSpec.describe Delivery, type: :model do
     let!(:status) { create(:shipment_status, closed: true) }
     let!(:shipment1) { create(:shipment, shipment_status: status) }
 
-
-    context "when all shipments are closed" do
-      let!(:shipment2) { create(:shipment, shipment_status: status) }
-      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, shipment: shipment1) }
-      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, shipment: shipment2) }
-
-      it "returns true" do
-        expect(delivery.can_be_closed?).to be(true)
+    context "when the delivery is already closed" do
+      it "returns false" do
+        delivery.status = :completed
+        expect(delivery.can_be_closed?).to be(false)
       end
     end
 
@@ -112,6 +108,16 @@ RSpec.describe Delivery, type: :model do
 
       it "returns false" do
         expect(delivery.can_be_closed?).to be(false)
+      end
+    end
+
+    context "when all conditions are met" do
+      let!(:shipment2) { create(:shipment, shipment_status: status) }
+      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, shipment: shipment1) }
+      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, shipment: shipment2) }
+
+      it "returns true" do
+        expect(delivery.can_be_closed?).to be(true)
       end
     end
 


### PR DESCRIPTION
## Description
There was an issue with the delivery show page. When a delivery was marked complete, the mark complete button would still show up.

## Approach Taken
Adds an additional check within the delivery model that confirms the shipment is active and not already closed.

## What Could Go Wrong?
This is a bug fix. Things are already going wrong.

## Remediation Strategy 
This is a bug fix. 
