### PR TITLE
XMDEV-229: Updates Create github release file to only run once CI finishes

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,11 +1,15 @@
 name: Create GitHub Release
 
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
   pull_request:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
     types:
       - opened
       - synchronize
@@ -20,7 +24,9 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
 
-    if: startsWith(github.head_ref, 'release-')
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.head_ref, 'release-')
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description
I didn't like how my create release workflow would interrupt CI when I was doing a release. So, I updated it so that it conditionally creates a release solely when CI passes.

## Approach Taken
Update the create release workflow to only run once standard CI finishes.

## What Could Go Wrong?
I might have made a mistake. At which point I'll need to update this workflow once more.

## Remediation Strategy 
NA. Simple simple github workflows update
