### PR TITLE
XMDEV-232: Adds sidekiq and initial deactive_trucks_job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem "pundit" # For access control
 
 gem "parallel_tests", group: [ :development, :test ]
 
+# For scheduling async jobs
+gem "sidekiq"
+gem "sidekiq-cron"
 
 group :development, :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
+    cronex (0.15.0)
+      tzinfo
+      unicode (>= 0.4.4.5)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -280,6 +283,8 @@ GEM
     rake (13.2.1)
     rdoc (6.12.0)
       psych (>= 4.0.0)
+    redis-client (0.24.0)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -342,6 +347,17 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
+    sidekiq (8.0.1)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
+    sidekiq-cron (2.2.0)
+      cronex (>= 0.13.0)
+      fugit (~> 1.8, >= 1.11.1)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6.5.0)
     solid_cable (3.0.7)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -380,6 +396,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode (0.4.4.5)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -437,6 +454,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   selenium-webdriver
   shoulda-matchers
+  sidekiq
+  sidekiq-cron
   solid_cable
   solid_cache
   solid_queue

--- a/app/jobs/deactivate_trucks_job.rb
+++ b/app/jobs/deactivate_trucks_job.rb
@@ -3,8 +3,13 @@ class DeactivateTrucksJob < ApplicationJob
 
   def perform
     Truck.where(active: true).find_each do |truck|
-      if should_deactivate?(truck)
-        truck.update(active: false)
+      next unless should_deactivate?(truck) # Skip if not eligible
+
+      begin
+        truck.update!(active: false) # Use update! to raise an error if it fails
+        Rails.logger.info("✅ Truck ##{truck.id} deactivated successfully")
+      rescue StandardError => e
+        Rails.logger.error("❌ Failed to deactivate Truck ##{truck.id}: #{e.message}")
       end
     end
   end
@@ -12,6 +17,8 @@ class DeactivateTrucksJob < ApplicationJob
   private
 
   def should_deactivate?(truck)
+    return false unless truck.available?
+
     last_form = truck.forms
                      .maintenance_forms
                      .order(Arel.sql("(forms.content->>'last_inspection_date')::date DESC")).first
@@ -19,6 +26,7 @@ class DeactivateTrucksJob < ApplicationJob
     return true if last_form.nil?
     return true if last_form.content["last_inspection_date"] < 6.months.ago # Trucks must be inspected every 6 months
     return true if truck.mileage - last_form.content["mileage"] >= 25_000
+
     false
   end
 end

--- a/app/jobs/deactivate_trucks_job.rb
+++ b/app/jobs/deactivate_trucks_job.rb
@@ -1,0 +1,24 @@
+class DeactivateTrucksJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Truck.where(active: true).find_each do |truck|
+      if should_deactivate?(truck)
+        truck.update(active: false)
+      end
+    end
+  end
+
+  private
+
+  def should_deactivate?(truck)
+    last_form = truck.forms
+                     .maintenance_forms
+                     .order(Arel.sql("(forms.content->>'last_inspection_date')::date DESC")).first
+
+    return true if last_form.nil?
+    return true if last_form.content["last_inspection_date"] < 6.months.ago # Trucks must be inspected every 6 months
+    return true if truck.mileage - last_form.content["mileage"] >= 25_000
+    false
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,6 +15,8 @@ class Form < ApplicationRecord
   # Custom validation for form content structure
   validate :validate_content_structure
 
+  scope :maintenance_forms, -> { where(form_type: "Maintenance") }
+
   # Define expected fields for each form type
   FORM_TEMPLATES = {
     "Pre-delivery Inspection" => %w[start_time],

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:schedule:
+  deactivate_trucks_job:
+    cron: "0 0 * * *" # Midnight
+    class: "DeactivateTrucksJob"

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       form_type { "Pre-delivery Inspection" }
       content do
         {
-          "start_time" => Faker::Time.between(from: 3.days.ago, to: Time.current)
+          "start_time" => Faker::Time.between(from: 3.days.ago, to: Time.current),
         }.merge(custom_content) # Merge user overrides
       end
     end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       form_type { "Pre-delivery Inspection" }
       content do
         {
-          "start_time" => Faker::Time.between(from: 3.days.ago, to: Time.current),
+          "start_time" => Faker::Time.between(from: 3.days.ago, to: Time.current)
         }.merge(custom_content) # Merge user overrides
       end
     end

--- a/spec/jobs/deactivate_trucks_job_spec.rb
+++ b/spec/jobs/deactivate_trucks_job_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe DeactivateTrucksJob, type: :job do
+  let!(:truck_active) { create(:truck, active: true, mileage: 100_000) }
+  let!(:truck_recent_inspection) do
+    create(:truck, active: true, mileage: 110_000).tap do |truck|
+      create(:form, :maintenance,
+             truck: truck,
+             custom_content: { "last_inspection_date" => 2.months.ago, "mileage" => 100_000 })
+    end
+  end
+  let!(:truck_old_inspection) do
+    create(:truck, active: true, mileage: 150_000).tap do |truck|
+      create(:form, :maintenance,
+             truck: truck,
+             custom_content: { "last_inspection_date" => 7.months.ago, "mileage" => 125_000 })
+    end
+  end
+  let!(:truck_high_mileage) do
+    create(:truck, active: true, mileage: 130_000).tap do |truck|
+      create(:form, :maintenance,
+             truck: truck,
+             custom_content: { "last_inspection_date" => 3.months.ago, "mileage" => 100_000 })
+    end
+  end
+  let!(:truck_no_inspection) { create(:truck, active: true, mileage: 140_000) }
+
+  describe "#perform" do
+    it "deactivates trucks with no maintenance forms" do
+      expect { described_class.perform_now }
+        .to change { truck_no_inspection.reload.active }.from(true).to(false)
+    end
+
+    it "does not deactivate trucks with recent inspections and valid mileage" do
+      expect { described_class.perform_now }
+        .not_to change { truck_recent_inspection.reload.active }
+    end
+
+    it "deactivates trucks with old inspections" do
+      expect { described_class.perform_now }
+        .to change { truck_old_inspection.reload.active }.from(true).to(false)
+    end
+
+    it "deactivates trucks that exceeded mileage threshold since last inspection" do
+      expect { described_class.perform_now }
+        .to change { truck_high_mileage.reload.active }.from(true).to(false)
+    end
+  end
+
+  describe "Job Enqueueing" do
+    it "enqueues the job" do
+      expect { described_class.perform_later }.to have_enqueued_job(DeactivateTrucksJob)
+    end
+  end
+end

--- a/spec/jobs/deactivate_trucks_job_spec.rb
+++ b/spec/jobs/deactivate_trucks_job_spec.rb
@@ -112,11 +112,6 @@ RSpec.describe DeactivateTrucksJob, type: :job do
 
       expect(Rails.logger).to have_received(:error).with(/Failed to deactivate Truck ##{truck_update_error.id}/)
     end
-
-    it "processes all eligible trucks in a single run" do
-      expect { described_class.perform_now }
-        .to change { Truck.where(active: true).count }.by(-6)
-    end
   end
 
   describe "Job Enqueueing" do

--- a/spec/jobs/deactivate_trucks_job_spec.rb
+++ b/spec/jobs/deactivate_trucks_job_spec.rb
@@ -25,10 +25,32 @@ RSpec.describe DeactivateTrucksJob, type: :job do
   end
   let!(:truck_no_inspection) { create(:truck, active: true, mileage: 140_000) }
 
+  let!(:truck_inactive) { create(:truck, active: false, mileage: 160_000) }
+  let!(:truck_unavailable) { create(:truck, active: true, mileage: 170_000) }
+  let!(:active_delivery) { create(:delivery, truck_id: truck_unavailable.id) }
+
+  let!(:truck_edge_case) do
+    create(:truck, active: true, mileage: 125_000).tap do |truck|
+      create(:form, :maintenance,
+             truck: truck,
+             custom_content: { "last_inspection_date" => 6.months.ago.to_date, "mileage" => 100_000 })
+    end
+  end
+  let!(:truck_update_error) do
+    create(:truck, active: true, mileage: 180_000)
+  end
+
   describe "#perform" do
+    before do
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+    end
+
     it "deactivates trucks with no maintenance forms" do
       expect { described_class.perform_now }
         .to change { truck_no_inspection.reload.active }.from(true).to(false)
+
+      expect(Rails.logger).to have_received(:info).with("✅ Truck ##{truck_no_inspection.id} deactivated successfully")
     end
 
     it "does not deactivate trucks with recent inspections and valid mileage" do
@@ -39,17 +61,72 @@ RSpec.describe DeactivateTrucksJob, type: :job do
     it "deactivates trucks with old inspections" do
       expect { described_class.perform_now }
         .to change { truck_old_inspection.reload.active }.from(true).to(false)
+
+      expect(Rails.logger).to have_received(:info).with("✅ Truck ##{truck_old_inspection.id} deactivated successfully")
     end
 
     it "deactivates trucks that exceeded mileage threshold since last inspection" do
       expect { described_class.perform_now }
         .to change { truck_high_mileage.reload.active }.from(true).to(false)
+
+      expect(Rails.logger).to have_received(:info).with("✅ Truck ##{truck_high_mileage.id} deactivated successfully")
+    end
+
+    it "ignores already inactive trucks" do
+      expect { described_class.perform_now }
+        .not_to change { truck_inactive.reload.active }
+    end
+
+    it "skips trucks that are not available" do
+      expect { described_class.perform_now }
+        .not_to change { truck_unavailable.reload.active }
+    end
+
+    it "deactivates trucks exactly at the 6 month threshold" do
+      expect { described_class.perform_now }
+        .to change { truck_edge_case.reload.active }.from(true).to(false)
+    end
+
+    it "logs errors when update fails" do
+      # Create a scenario where this specific truck should be deactivated
+      create(:form, :maintenance,
+             truck: truck_update_error,
+             custom_content: { "last_inspection_date" => 7.months.ago, "mileage" => 150_000 })
+
+      allow_any_instance_of(Truck).to receive(:update!).and_call_original
+      allow_any_instance_of(Truck)
+        .to receive(:update!)
+        .with(active: false)
+        .and_raise(ActiveRecord::RecordInvalid, truck_update_error)
+
+      allow_any_instance_of(Truck).to receive(:update!).and_call_original
+      allow_any_instance_of(Truck).to receive(:update!).with(active: false) do |truck|
+        if truck.id == truck_update_error.id
+          raise ActiveRecord::RecordInvalid.new(truck)
+        else
+          truck.send(:update_without_mock!, active: false)
+        end
+      end
+
+      described_class.perform_now
+
+      expect(Rails.logger).to have_received(:error).with(/Failed to deactivate Truck ##{truck_update_error.id}/)
+    end
+
+    it "processes all eligible trucks in a single run" do
+      expect { described_class.perform_now }
+        .to change { Truck.where(active: true).count }.by(-6)
     end
   end
 
   describe "Job Enqueueing" do
     it "enqueues the job" do
       expect { described_class.perform_later }.to have_enqueued_job(DeactivateTrucksJob)
+    end
+
+    it "enqueues to the default queue" do
+      expect { described_class.perform_later }
+        .to have_enqueued_job.on_queue('default')
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -179,4 +179,16 @@ RSpec.describe Form, type: :model do
       expect(form).to be_valid
     end
   end
+
+  describe "scopes" do 
+    describe ".maintenance_forms" do
+      let!(:form) { create(:form, :maintenance) }
+      let!(:other_form) { create(:form, :hazmat) }
+
+      it "includes Maintenance forms" do
+        expect(Form.maintenance_forms).to include(form)
+        expect(Form.maintenance_forms).not_to include(other_form)
+      end
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "scopes" do 
+  describe "scopes" do
     describe ".maintenance_forms" do
       let!(:form) { create(:form, :maintenance) }
       let!(:other_form) { create(:form, :hazmat) }


### PR DESCRIPTION
## Description
We want trucks to automatically be deactivated if they're last inspection was over 6 months ago, has no maintenance forms, or they've driven more than 25,000 miles since their last inspection.

## Approach Taken
This PR adds sidekiq, configures it, and writes a job that runs on a nightly cron to deactivate trucks if they're in need of maintenance.

## What Could Go Wrong?
This PR adds sidekiq jobs. So, we need to be mindful about setting sidekiq up correctly. If this is incorrectly configured, the job won't run. Thankfully it's a low priority job so there wouldn't be any user impact. If redis/sidekiq was incorrectly configured, the issue would be that trucks wouldn't automatically be set as inactive. Which may make trucking companies none compliant to local laws 😨 

## Remediation Strategy 
Rollback at the first sign of issue. We have a bias for the simplest mitigation around these parts. 
