### PR TITLE
Add idempotent helper

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module TruckinAlong
     config.autoload_lib(ignore: %w[assets tasks])
     config.autoload_paths += %W[#{config.root}/app/services]
     config.autoload_paths += %W[#{config.root}/app/validators]
+    config.autoload_paths << Rails.root.join('lib')
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ module TruckinAlong
     config.autoload_lib(ignore: %w[assets tasks])
     config.autoload_paths += %W[#{config.root}/app/services]
     config.autoload_paths += %W[#{config.root}/app/validators]
-    config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join("lib")
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/migration_helpers/idempotent_migration.rb
+++ b/lib/migration_helpers/idempotent_migration.rb
@@ -1,0 +1,15 @@
+module MigrationHelpers
+  module IdempotentMigration
+    def add_column_unless_exists(table_name, column_name, type, **options)
+      unless column_exists?(table_name, column_name)
+        add_column(table_name, column_name, type, **options)
+      end
+    end
+
+    def remove_column_if_exists(table_name, column_name)
+      if column_exists?(table_name, column_name)
+        remove_column(table_name, column_name)
+      end
+    end
+  end
+end

--- a/spec/lib/migration_helpers/idempotent_migration_spec.rb
+++ b/spec/lib/migration_helpers/idempotent_migration_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe MigrationHelpers::IdempotentMigration do
+  let(:dummy_class) do
+    Class.new(ActiveRecord::Migration[8.0]) do
+      include MigrationHelpers::IdempotentMigration
+    end.new
+  end
+
+  before do
+    # Create a dummy table
+    ActiveRecord::Schema.define do
+      create_table :dummy_shipments, force: true do |t|
+        t.timestamps
+      end
+    end
+  end
+
+  after do
+    # Clean up the dummy table
+    ActiveRecord::Schema.define do
+      drop_table :dummy_shipments, if_exists: true
+    end
+  end
+
+  describe '#add_column_unless_exists' do
+    it 'adds a new column if it does not exist' do
+      expect {
+        dummy_class.add_column_unless_exists(:dummy_shipments, :test_latitude, :float)
+      }.to change {
+        ActiveRecord::Base.connection.column_exists?(:dummy_shipments, :test_latitude)
+      }.from(false).to(true)
+    end
+
+    it 'does not add the column if it already exists' do
+      dummy_class.add_column_unless_exists(:dummy_shipments, :test_latitude, :float)
+
+      expect {
+        dummy_class.add_column_unless_exists(:dummy_shipments, :test_latitude, :float)
+      }.not_to change {
+        ActiveRecord::Base.connection.columns(:dummy_shipments).size
+      }
+    end
+  end
+
+  describe '#remove_column_if_exists' do
+    it 'removes a column if it exists' do
+      dummy_class.add_column_unless_exists(:dummy_shipments, :test_longitude, :float)
+
+      expect {
+        dummy_class.remove_column_if_exists(:dummy_shipments, :test_longitude)
+      }.to change {
+        ActiveRecord::Base.connection.column_exists?(:dummy_shipments, :test_longitude)
+      }.from(true).to(false)
+    end
+
+    it 'does nothing if the column does not exist' do
+      expect {
+        dummy_class.remove_column_if_exists(:dummy_shipments, :non_existing_column)
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Description
Johnny boy was getting tired of manually writing idempotent migrations for every column. So, I opted to create a migration helper that will do this for me.

## Approach Taken
Created an idempotent migration helper and associated spec file. I've tested it extensively locally, now checking it our in a github env.

## What Could Go Wrong?
This change is high impact, and carries significantly higher risk given it's associated with our data schema. If there is an issue, once it's being used, it will directly impact our migrations.

## Remediation Strategy 
This helper will most likely be used in all migrations going forward. Once this is deployed, we need to observe it's correct operation in production. If not working, rollback if needed.
