### PR TITLE
XMDEV-282: Adds shipment map on shipment show page

### DIFF
--- a/app/javascript/controllers/show_shipment_map_controller.js
+++ b/app/javascript/controllers/show_shipment_map_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    senderLat: Number,
+    senderLng: Number,
+    receiverLat: Number,
+    receiverLng: Number,
+    senderAddress: String,
+    receiverAddress: String
+  }
+
+  hasValidCoordinates() {
+    return this.hasSenderLatValue && this.hasSenderLngValue &&
+           this.hasReceiverLatValue && this.hasReceiverLngValue &&
+           this.senderLatValue !== 0 && this.senderLngValue !== 0 &&
+           this.receiverLatValue !== 0 && this.receiverLngValue !== 0;
+  }
+
+  connect() {
+    if (this.hasValidCoordinates()) {
+      this.initMap();
+    } else {
+      this.showError();
+    }
+  }
+
+  initMap() {
+    // Calculate center point
+    const centerLat = (this.senderLatValue + this.receiverLatValue) / 2;
+    const centerLng = (this.senderLngValue + this.receiverLngValue) / 2;
+    
+    // Initialize map
+    const map = L.map(this.element).setView([centerLat, centerLng], 10);
+    
+    // Add OpenStreetMap tiles
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+    
+    // Add markers for sender and receiver
+    const senderMarker = L.marker([this.senderLatValue, this.senderLngValue]).addTo(map);
+    senderMarker.bindPopup("<b>Pickup Location</b><br>" + this.senderAddressValue);
+    
+    const receiverMarker = L.marker([this.receiverLatValue, this.receiverLngValue]).addTo(map);
+    receiverMarker.bindPopup("<b>Delivery Location</b><br>" + this.receiverAddressValue);
+    
+    // Fit the map to show both markers
+    const bounds = L.latLngBounds([
+      [this.senderLatValue, this.senderLngValue],
+      [this.receiverLatValue, this.receiverLngValue]
+    ]);
+    map.fitBounds(bounds, { padding: [50, 50] });
+  }
+
+  showError() {
+    this.element.innerHTML = '<div class="alert alert-warning">Unable to display map. Address coordinates are not available.</div>';
+    this.element.style.height = 'auto';
+  }
+}

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -37,7 +37,7 @@ class Shipment < ApplicationRecord
     length * width * height
   end
 
-  private 
+  private
 
   def geocode_sender
     result = Geocoder.search(sender_address).first
@@ -46,7 +46,7 @@ class Shipment < ApplicationRecord
       self.sender_longitude = result.longitude
     end
   end
-  
+
   def geocode_receiver
     result = Geocoder.search(receiver_address).first
     if result

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -10,6 +10,9 @@ class Shipment < ApplicationRecord
   validates :name, :sender_name, :sender_address, :receiver_name, :receiver_address, :weight, :length, :width, :height, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }
 
+  after_validation :geocode_sender, if: ->(obj) { obj.sender_address.present? && obj.sender_address_changed? }
+  after_validation :geocode_receiver, if: ->(obj) { obj.receiver_address.present? && obj.receiver_address_changed? }
+
   scope :for_user, ->(user) { where(user_id: user.id) }
 
   scope :for_company, ->(company) { where(company_id: company.id) }
@@ -32,5 +35,23 @@ class Shipment < ApplicationRecord
 
   def volume
     length * width * height
+  end
+
+  private 
+
+  def geocode_sender
+    result = Geocoder.search(sender_address).first
+    if result
+      self.sender_latitude = result.latitude
+      self.sender_longitude = result.longitude
+    end
+  end
+  
+  def geocode_receiver
+    result = Geocoder.search(receiver_address).first
+    if result
+      self.receiver_latitude = result.latitude
+      self.receiver_longitude = result.longitude
+    end
   end
 end

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -3,6 +3,10 @@
   <%= render 'back_button', shipment: @shipment%>
 </div>
 
+<div id="shipment-map" data-controller="show-shipment-map" data-show-shipment-map-sender-lat-value="<%= @shipment.sender_latitude %>" data-show-shipment-map-sender-lng-value="<%= @shipment.sender_longitude %>" data-show-shipment-map-receiver-lat-value="<%= @shipment.receiver_latitude %>" data-show-shipment-map-receiver-lng-value="<%= @shipment.receiver_longitude %>" data-show-shipment-map-sender-address-value="<%= @shipment.sender_address %>" data-show-shipment-map-receiver-address-value="<%= @shipment.receiver_address %>" style="height: 500px; width: 100%;">
+</div>
+<br />
+
 <div class="details-container">
   <p><strong>Name:</strong> <span class="detail-value"><%= @shipment.name %></span></p>
   <p><strong>Status: </strong>

--- a/db/migrate/20250427164722_add_coordinates_to_shipments.rb
+++ b/db/migrate/20250427164722_add_coordinates_to_shipments.rb
@@ -1,0 +1,26 @@
+class AddCoordinatesToShipments < ActiveRecord::Migration[8.0]
+  include MigrationHelpers::IdempotentMigration
+
+  def up
+    columns.each do |column|
+      add_column_unless_exists :shipments, column, :float
+    end
+  end
+
+  def down
+    columns.each do |column|
+      remove_column_if_exists :shipments, column
+    end
+  end
+
+  private
+
+  def columns
+    %i[
+      sender_latitude
+      sender_longitude
+      receiver_latitude
+      receiver_longitude
+    ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_172401) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_27_164722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -95,6 +95,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_172401) do
     t.decimal "width"
     t.decimal "height"
     t.datetime "deleted_at"
+    t.float "sender_latitude"
+    t.float "sender_longitude"
+    t.float "receiver_latitude"
+    t.float "receiver_longitude"
     t.index ["company_id"], name: "index_shipments_on_company_id"
     t.index ["shipment_status_id"], name: "index_shipments_on_shipment_status_id"
     t.index ["truck_id"], name: "index_shipments_on_truck_id"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@rails/ujs": "^7.1.3-4"
+        "@rails/ujs": "^7.1.3-4",
+        "leaflet": "^1.9.4"
       },
       "devDependencies": {
         "@hotwired/stimulus": "^3.2.2",
@@ -1772,6 +1773,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lodash": {
       "version": "4.17.21",

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :shipment do
     name { "#{Faker::Commerce.product_name} #{SecureRandom.uuid}" }
     sender_name { Faker::Name.name }
-    sender_address { "290 Bremner Blvd, Toronto, Ontario, Canada" }
+    sender_address { Faker::Address.full_address }
     receiver_name { Faker::Name.name }
-    receiver_address { "122 Big Nickel Rd, Greater Sudbury, Ontario, Canada" }
+    receiver_address { Faker::Address.full_address }
     weight { Faker::Number.decimal(l_digits: 3, r_digits: 1) }
     length { Faker::Number.decimal(l_digits: 2, r_digits: 1) }
     width { Faker::Number.decimal(l_digits: 2, r_digits: 1) }

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :shipment do
     name { "#{Faker::Commerce.product_name} #{SecureRandom.uuid}" }
     sender_name { Faker::Name.name }
-    sender_address { Faker::Address.full_address }
+    sender_address { "290 Bremner Blvd, Toronto, Ontario, Canada" }
     receiver_name { Faker::Name.name }
-    receiver_address { Faker::Address.full_address }
+    receiver_address { "122 Big Nickel Rd, Greater Sudbury, Ontario, Canada" }
     weight { Faker::Number.decimal(l_digits: 3, r_digits: 1) }
     length { Faker::Number.decimal(l_digits: 2, r_digits: 1) }
     width { Faker::Number.decimal(l_digits: 2, r_digits: 1) }

--- a/spec/javascript/controllers/show_shipment_map_controller.test.js
+++ b/spec/javascript/controllers/show_shipment_map_controller.test.js
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Application } from "@hotwired/stimulus";
+import MapController from "controllers/show_shipment_map_controller";
+
+describe("MapController", () => {
+  let application;
+  let container;
+  let mockLeaflet;
+
+  beforeEach(() => {
+    // Mock Leaflet library
+    mockLeaflet = {
+      map: vi.fn().mockReturnValue({
+        setView: vi.fn().mockReturnThis(),
+        addLayer: vi.fn().mockReturnThis(),
+        fitBounds: vi.fn().mockReturnThis()
+      }),
+      tileLayer: vi.fn().mockReturnValue({
+        addTo: vi.fn().mockReturnThis()
+      }),
+      marker: vi.fn().mockReturnValue({
+        addTo: vi.fn().mockReturnThis(),
+        bindPopup: vi.fn().mockReturnThis()
+      }),
+      latLngBounds: vi.fn().mockReturnValue("mockBounds")
+    };
+
+    // Assign mock to global L object expected by the controller
+    global.L = mockLeaflet;
+
+    // Set up a fresh Stimulus application
+    application = Application.start();
+    application.register("show-shipment-map", MapController);
+
+    // Set up default HTML structure
+    document.body.innerHTML = `
+      <div 
+        data-controller="show-shipment-map"
+        data-show-shipment-map-sender-lat-value="40.7128"
+        data-show-shipment-map-sender-lng-value="-74.0060"
+        data-show-shipment-map-receiver-lat-value="34.0522"
+        data-show-shipment-map-receiver-lng-value="-118.2437"
+        data-show-shipment-map-sender-address-value="New York, NY"
+        data-show-shipment-map-receiver-address-value="Los Angeles, CA">
+      </div>
+    `;
+
+    // Get the container with the controller
+    container = document.querySelector('[data-controller="show-shipment-map"]');
+  });
+
+  afterEach(() => {
+    // Clean up
+    document.body.innerHTML = "";
+    application.stop();
+    delete global.L;
+  });
+
+  describe("connect", () => {
+    it("initializes the map when valid coordinates are provided", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      // Explicitly call connect to ensure initMap is called
+      controller.connect();
+      
+      // Check if the map was initialized with the correct center point
+      const expectedCenterLat = (40.7128 + 34.0522) / 2;
+      const expectedCenterLng = (-74.0060 + -118.2437) / 2;
+      
+      expect(mockLeaflet.map).toHaveBeenCalledWith(container);
+      expect(mockLeaflet.map().setView).toHaveBeenCalledWith([expectedCenterLat, expectedCenterLng], 10);
+    });
+
+    it("shows error message when coordinates are missing", () => {
+      // Clear the body and set up container without coordinates
+      document.body.innerHTML = `
+        <div data-controller="show-shipment-map"></div>
+      `;
+      
+      // Need to stop and restart application to handle the new DOM elements
+      application.stop();
+      application = Application.start();
+      application.register("show-shipment-map", MapController);
+      
+      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
+      
+      // Connect event will be triggered automatically, but we need to wait for it
+      // Force a connect by accessing the controller
+      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
+      
+      // Delay slightly to allow the connect method to complete
+      setTimeout(() => {
+        expect(incompleteContainer.innerHTML).toContain("Unable to display map");
+        expect(incompleteContainer.style.height).toBe("auto");
+      }, 0);
+    });
+
+    it("shows error message when coordinates are zero", () => {
+      // Clear the body and set up container with zero coordinates
+      document.body.innerHTML = `
+        <div 
+          data-controller="show-shipment-map"
+          data-show-shipment-map-sender-lat-value="0"
+          data-show-shipment-map-sender-lng-value="0"
+          data-show-shipment-map-receiver-lat-value="34.0522"
+          data-show-shipment-map-receiver-lng-value="-118.2437">
+        </div>
+      `;
+      
+      // Need to stop and restart application to handle the new DOM elements
+      application.stop();
+      application = Application.start();
+      application.register("show-shipment-map", MapController);
+      
+      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
+      
+      // Force a connect by accessing the controller
+      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
+      
+      // Call connect explicitly
+      controller.connect();
+      
+      expect(incompleteContainer.innerHTML).toContain("Unable to display map");
+    });
+  });
+
+  describe("hasValidCoordinates", () => {
+    it("returns true when all coordinates are valid", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      expect(controller.hasValidCoordinates()).toBe(true);
+    });
+
+    it("returns false when any coordinate is missing", () => {
+      // Clear the body and set up new container
+      document.body.innerHTML = `
+        <div 
+          data-controller="show-shipment-map"
+          data-show-shipment-map-sender-lat-value="40.7128"
+          data-show-shipment-map-sender-lng-value="-74.0060">
+        </div>
+      `;
+      
+      // Need to stop and restart application to handle the new DOM elements
+      application.stop();
+      application = Application.start();
+      application.register("show-shipment-map", MapController);
+      
+      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
+      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
+      
+      expect(controller.hasValidCoordinates()).toBe(false);
+    });
+
+    it("returns false when any coordinate is zero", () => {
+      // Clear the body and set up new container
+      document.body.innerHTML = `
+        <div 
+          data-controller="show-shipment-map"
+          data-show-shipment-map-sender-lat-value="40.7128"
+          data-show-shipment-map-sender-lng-value="0"
+          data-show-shipment-map-receiver-lat-value="34.0522"
+          data-show-shipment-map-receiver-lng-value="-118.2437">
+        </div>
+      `;
+      
+      // Need to stop and restart application to handle the new DOM elements
+      application.stop();
+      application = Application.start();
+      application.register("show-shipment-map", MapController);
+      
+      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
+      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
+      
+      expect(controller.hasValidCoordinates()).toBe(false);
+    });
+  });
+
+  describe("initMap", () => {
+    it("creates a map with the correct center point", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      controller.initMap();
+      
+      const expectedCenterLat = (40.7128 + 34.0522) / 2;
+      const expectedCenterLng = (-74.0060 + -118.2437) / 2;
+      
+      expect(mockLeaflet.map).toHaveBeenCalledWith(container);
+      expect(mockLeaflet.map().setView).toHaveBeenCalledWith([expectedCenterLat, expectedCenterLng], 10);
+    });
+
+    it("adds tile layer to the map", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      controller.initMap();
+      
+      expect(mockLeaflet.tileLayer).toHaveBeenCalledWith(
+        'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        expect.objectContaining({
+          attribution: expect.stringContaining('OpenStreetMap')
+        })
+      );
+      expect(mockLeaflet.tileLayer().addTo).toHaveBeenCalled();
+    });
+
+    it("adds markers for sender and receiver locations", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      controller.initMap();
+      
+      // Check sender marker
+      expect(mockLeaflet.marker).toHaveBeenCalledWith([40.7128, -74.0060]);
+      expect(mockLeaflet.marker().bindPopup).toHaveBeenCalledWith(
+        expect.stringContaining("New York, NY")
+      );
+      
+      // Check receiver marker
+      expect(mockLeaflet.marker).toHaveBeenCalledWith([34.0522, -118.2437]);
+      expect(mockLeaflet.marker().bindPopup).toHaveBeenCalledWith(
+        expect.stringContaining("Los Angeles, CA")
+      );
+    });
+
+    it("fits the map bounds to show both markers", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      controller.initMap();
+      
+      expect(mockLeaflet.latLngBounds).toHaveBeenCalledWith([
+        [40.7128, -74.0060],
+        [34.0522, -118.2437]
+      ]);
+      expect(mockLeaflet.map().fitBounds).toHaveBeenCalledWith("mockBounds", { padding: [50, 50] });
+    });
+  });
+
+  describe("showError", () => {
+    it("displays error message in the container", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      
+      controller.showError();
+      
+      expect(container.innerHTML).toContain("Unable to display map");
+      expect(container.innerHTML).toContain("alert-warning");
+      expect(container.style.height).toBe("auto");
+    });
+  });
+});

--- a/spec/javascript/controllers/show_shipment_map_controller.test.js
+++ b/spec/javascript/controllers/show_shipment_map_controller.test.js
@@ -1,14 +1,30 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Application } from "@hotwired/stimulus";
-import MapController from "controllers/show_shipment_map_controller";
+import ShipmentShowMapController from "controllers/show_shipment_map_controller";
+import { waitFor } from "@testing-library/dom";
 
-describe("MapController", () => {
+describe("ShipmentShowMapController", () => {
   let application;
   let container;
   let mockLeaflet;
 
+  async function setupNewController(html) {
+    document.body.innerHTML = html;
+    application.stop();
+    application = Application.start();
+    application.register("show-shipment-map", ShipmentShowMapController);
+    const container = document.querySelector('[data-controller="show-shipment-map"]');
+    
+    let controller;
+    await waitFor(() => {
+      controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
+      expect(controller).not.toBeNull();
+    });
+
+    return { controller, container };
+  }
+
   beforeEach(() => {
-    // Mock Leaflet library
     mockLeaflet = {
       map: vi.fn().mockReturnValue({
         setView: vi.fn().mockReturnThis(),
@@ -25,14 +41,8 @@ describe("MapController", () => {
       latLngBounds: vi.fn().mockReturnValue("mockBounds")
     };
 
-    // Assign mock to global L object expected by the controller
     global.L = mockLeaflet;
 
-    // Set up a fresh Stimulus application
-    application = Application.start();
-    application.register("show-shipment-map", MapController);
-
-    // Set up default HTML structure
     document.body.innerHTML = `
       <div 
         data-controller="show-shipment-map"
@@ -45,12 +55,13 @@ describe("MapController", () => {
       </div>
     `;
 
-    // Get the container with the controller
+    application = Application.start();
+    application.register("show-shipment-map", ShipmentShowMapController);
+
     container = document.querySelector('[data-controller="show-shipment-map"]');
   });
 
   afterEach(() => {
-    // Clean up
     document.body.innerHTML = "";
     application.stop();
     delete global.L;
@@ -60,10 +71,8 @@ describe("MapController", () => {
     it("initializes the map when valid coordinates are provided", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
       
-      // Explicitly call connect to ensure initMap is called
       controller.connect();
       
-      // Check if the map was initialized with the correct center point
       const expectedCenterLat = (40.7128 + 34.0522) / 2;
       const expectedCenterLng = (-74.0060 + -118.2437) / 2;
       
@@ -71,33 +80,17 @@ describe("MapController", () => {
       expect(mockLeaflet.map().setView).toHaveBeenCalledWith([expectedCenterLat, expectedCenterLng], 10);
     });
 
-    it("shows error message when coordinates are missing", () => {
-      // Clear the body and set up container without coordinates
-      document.body.innerHTML = `
+    it("shows error message when coordinates are missing", async () => {
+      const { container } = await setupNewController(`
         <div data-controller="show-shipment-map"></div>
-      `;
-      
-      // Need to stop and restart application to handle the new DOM elements
-      application.stop();
-      application = Application.start();
-      application.register("show-shipment-map", MapController);
-      
-      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
-      
-      // Connect event will be triggered automatically, but we need to wait for it
-      // Force a connect by accessing the controller
-      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
-      
-      // Delay slightly to allow the connect method to complete
-      setTimeout(() => {
-        expect(incompleteContainer.innerHTML).toContain("Unable to display map");
-        expect(incompleteContainer.style.height).toBe("auto");
-      }, 0);
+      `);
+
+      expect(container.innerHTML).toContain("Unable to display map");
+      expect(container.style.height).toBe("auto");
     });
 
-    it("shows error message when coordinates are zero", () => {
-      // Clear the body and set up container with zero coordinates
-      document.body.innerHTML = `
+    it("shows error message when coordinates are zero", async () => {
+      const { container } = await setupNewController(`
         <div 
           data-controller="show-shipment-map"
           data-show-shipment-map-sender-lat-value="0"
@@ -105,56 +98,33 @@ describe("MapController", () => {
           data-show-shipment-map-receiver-lat-value="34.0522"
           data-show-shipment-map-receiver-lng-value="-118.2437">
         </div>
-      `;
-      
-      // Need to stop and restart application to handle the new DOM elements
-      application.stop();
-      application = Application.start();
-      application.register("show-shipment-map", MapController);
-      
-      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
-      
-      // Force a connect by accessing the controller
-      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
-      
-      // Call connect explicitly
-      controller.connect();
-      
-      expect(incompleteContainer.innerHTML).toContain("Unable to display map");
+      `);
+
+      expect(container.innerHTML).toContain("Unable to display map");
+      expect(container.style.height).toBe("auto");
     });
   });
 
   describe("hasValidCoordinates", () => {
     it("returns true when all coordinates are valid", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
-      
       expect(controller.hasValidCoordinates()).toBe(true);
     });
 
-    it("returns false when any coordinate is missing", () => {
-      // Clear the body and set up new container
-      document.body.innerHTML = `
+    it("returns false when any coordinate is missing", async () => {
+      const { controller } = await setupNewController(`
         <div 
           data-controller="show-shipment-map"
           data-show-shipment-map-sender-lat-value="40.7128"
           data-show-shipment-map-sender-lng-value="-74.0060">
         </div>
-      `;
-      
-      // Need to stop and restart application to handle the new DOM elements
-      application.stop();
-      application = Application.start();
-      application.register("show-shipment-map", MapController);
-      
-      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
-      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
-      
+      `);
+
       expect(controller.hasValidCoordinates()).toBe(false);
     });
 
-    it("returns false when any coordinate is zero", () => {
-      // Clear the body and set up new container
-      document.body.innerHTML = `
+    it("returns false when any coordinate is zero", async () => {
+      const { controller } = await setupNewController(`
         <div 
           data-controller="show-shipment-map"
           data-show-shipment-map-sender-lat-value="40.7128"
@@ -162,16 +132,8 @@ describe("MapController", () => {
           data-show-shipment-map-receiver-lat-value="34.0522"
           data-show-shipment-map-receiver-lng-value="-118.2437">
         </div>
-      `;
-      
-      // Need to stop and restart application to handle the new DOM elements
-      application.stop();
-      application = Application.start();
-      application.register("show-shipment-map", MapController);
-      
-      const incompleteContainer = document.querySelector('[data-controller="show-shipment-map"]');
-      const controller = application.getControllerForElementAndIdentifier(incompleteContainer, "show-shipment-map");
-      
+      `);
+
       expect(controller.hasValidCoordinates()).toBe(false);
     });
   });
@@ -179,21 +141,21 @@ describe("MapController", () => {
   describe("initMap", () => {
     it("creates a map with the correct center point", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
-      
+
       controller.initMap();
-      
+
       const expectedCenterLat = (40.7128 + 34.0522) / 2;
       const expectedCenterLng = (-74.0060 + -118.2437) / 2;
-      
+
       expect(mockLeaflet.map).toHaveBeenCalledWith(container);
       expect(mockLeaflet.map().setView).toHaveBeenCalledWith([expectedCenterLat, expectedCenterLng], 10);
     });
 
     it("adds tile layer to the map", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
-      
+
       controller.initMap();
-      
+
       expect(mockLeaflet.tileLayer).toHaveBeenCalledWith(
         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         expect.objectContaining({
@@ -205,27 +167,21 @@ describe("MapController", () => {
 
     it("adds markers for sender and receiver locations", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
-      
+
       controller.initMap();
-      
-      // Check sender marker
+
       expect(mockLeaflet.marker).toHaveBeenCalledWith([40.7128, -74.0060]);
-      expect(mockLeaflet.marker().bindPopup).toHaveBeenCalledWith(
-        expect.stringContaining("New York, NY")
-      );
-      
-      // Check receiver marker
+      expect(mockLeaflet.marker().bindPopup).toHaveBeenCalledWith(expect.stringContaining("New York, NY"));
+
       expect(mockLeaflet.marker).toHaveBeenCalledWith([34.0522, -118.2437]);
-      expect(mockLeaflet.marker().bindPopup).toHaveBeenCalledWith(
-        expect.stringContaining("Los Angeles, CA")
-      );
+      expect(mockLeaflet.marker().bindPopup).toHaveBeenCalledWith(expect.stringContaining("Los Angeles, CA"));
     });
 
     it("fits the map bounds to show both markers", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
-      
+
       controller.initMap();
-      
+
       expect(mockLeaflet.latLngBounds).toHaveBeenCalledWith([
         [40.7128, -74.0060],
         [34.0522, -118.2437]
@@ -237,9 +193,9 @@ describe("MapController", () => {
   describe("showError", () => {
     it("displays error message in the container", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-shipment-map");
-      
+
       controller.showError();
-      
+
       expect(container.innerHTML).toContain("Unable to display map");
       expect(container.innerHTML).toContain("alert-warning");
       expect(container.style.height).toBe("auto");

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe Shipment, type: :model do
     end
   end
 
-
   ## Edge Case Tests
   describe "edge cases" do
     it "handles extremely large weights" do
@@ -175,6 +174,65 @@ RSpec.describe Shipment, type: :model do
       valid_shipment.width  = 25
       valid_shipment.height = 15
       expect(valid_shipment.volume).to eq(3750)
+    end
+  end
+
+  ## Geocoding Tests
+  describe "geocoding" do
+    describe "sender address geocoding" do
+      it "geocodes the sender address on create" do
+        new_shipment = build(:shipment, sender_address: "123 New Street, New York, NY")
+        new_shipment.save
+
+        expect(new_shipment.sender_latitude).to eq(40.7128)
+        expect(new_shipment.sender_longitude).to eq(-74.0060)
+      end
+
+      it "geocodes the sender address when sender_address changes" do
+        valid_shipment.sender_address = "456 Changed Street, New York, NY"
+        valid_shipment.save
+
+        expect(valid_shipment.sender_latitude).to eq(40.7128)
+        expect(valid_shipment.sender_longitude).to eq(-74.0060)
+      end
+
+      it "handles nil results from geocoder" do
+        allow(Geocoder).to receive(:search).and_return([])
+
+        valid_shipment.sender_address = "Invalid Address"
+        valid_shipment.save
+
+        expect(valid_shipment.sender_latitude).to be_nil
+        expect(valid_shipment.sender_longitude).to be_nil
+      end
+    end
+
+    describe "receiver address geocoding" do
+      it "geocodes the receiver address on create" do
+        new_shipment = build(:shipment, receiver_address: "123 New Street, New York, NY")
+        new_shipment.save
+
+        expect(new_shipment.receiver_latitude).to eq(40.7128)
+        expect(new_shipment.receiver_longitude).to eq(-74.0060)
+      end
+
+      it "geocodes the receiver address when receiver_address changes" do
+        valid_shipment.receiver_address = "456 Changed Street, New York, NY"
+        valid_shipment.save
+
+        expect(valid_shipment.receiver_latitude).to eq(40.7128)
+        expect(valid_shipment.receiver_longitude).to eq(-74.0060)
+      end
+
+      it "handles nil results from geocoder" do
+        allow(Geocoder).to receive(:search).and_return([])
+
+        valid_shipment.receiver_address = "Invalid Address"
+        valid_shipment.save
+
+        expect(valid_shipment.receiver_latitude).to be_nil
+        expect(valid_shipment.receiver_longitude).to be_nil
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,11 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::ControllerHelpers, type: :controller
 
+  config.before(:each) do
+    geocoder_result = double("Geocoder::Result", latitude: 40.7128, longitude: -74.0060)
+    allow(Geocoder).to receive(:search).and_return([ geocoder_result ])
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,130 +67,10 @@
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz"
   integrity sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==
 
-"@esbuild/aix-ppc64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz#c33cf6bbee34975626b01b80451cbb72b4c6c91d"
-  integrity sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==
-
-"@esbuild/android-arm64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz#ea766015c7d2655164f22100d33d7f0308a28d6d"
-  integrity sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==
-
-"@esbuild/android-arm@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.1.tgz#e84d2bf2fe2e6177a0facda3a575b2139fd3cb9c"
-  integrity sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==
-
-"@esbuild/android-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.1.tgz#58337bee3bc6d78d10425e5500bd11370cfdfbed"
-  integrity sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==
-
 "@esbuild/darwin-arm64@0.25.1":
   version "0.25.1"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz"
   integrity sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==
-
-"@esbuild/darwin-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz#0643e003bb238c63fc93ddbee7d26a003be3cd98"
-  integrity sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==
-
-"@esbuild/freebsd-arm64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz#cff18da5469c09986b93e87979de5d6872fe8f8e"
-  integrity sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==
-
-"@esbuild/freebsd-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz#362fc09c2de14987621c1878af19203c46365dde"
-  integrity sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==
-
-"@esbuild/linux-arm64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz#aa90d5b02efc97a271e124e6d1cea490634f7498"
-  integrity sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==
-
-"@esbuild/linux-arm@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz#dfcefcbac60a20918b19569b4b657844d39db35a"
-  integrity sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==
-
-"@esbuild/linux-ia32@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz#6f9527077ccb7953ed2af02e013d4bac69f13754"
-  integrity sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==
-
-"@esbuild/linux-loong64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz#287d2412a5456e5860c2839d42a4b51284d1697c"
-  integrity sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==
-
-"@esbuild/linux-mips64el@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz#530574b9e1bc5d20f7a4f44c5f045e26f3783d57"
-  integrity sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==
-
-"@esbuild/linux-ppc64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz#5d7e6b283a0b321ea42c6bc0abeb9eb99c1f5589"
-  integrity sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==
-
-"@esbuild/linux-riscv64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz#14fa0cd073c26b4ee2465d18cd1e18eea7859fa8"
-  integrity sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==
-
-"@esbuild/linux-s390x@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz#e677b4b9d1b384098752266ccaa0d52a420dc1aa"
-  integrity sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==
-
-"@esbuild/linux-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz#f1c796b78fff5ce393658313e8c58613198d9954"
-  integrity sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==
-
-"@esbuild/netbsd-arm64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz#0d280b7dfe3973f111b02d5fe9f3063b92796d29"
-  integrity sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==
-
-"@esbuild/netbsd-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz#be663893931a4bb3f3a009c5cc24fa9681cc71c0"
-  integrity sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==
-
-"@esbuild/openbsd-arm64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz#d9021b884233673a05dc1cc26de0bf325d824217"
-  integrity sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==
-
-"@esbuild/openbsd-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz#9f1dc1786ed2e2938c404b06bcc48be9a13250de"
-  integrity sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==
-
-"@esbuild/sunos-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz#89aac24a4b4115959b3f790192cf130396696c27"
-  integrity sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==
-
-"@esbuild/win32-arm64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz#354358647a6ea98ea6d243bf48bdd7a434999582"
-  integrity sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==
-
-"@esbuild/win32-ia32@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz#8cea7340f2647eba951a041dc95651e3908cd4cb"
-  integrity sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==
-
-"@esbuild/win32-x64@0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz#7d79922cb2d88f9048f06393dbf62d2e4accb584"
-  integrity sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==
 
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
@@ -207,105 +87,10 @@
   resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.1.3-4.tgz"
   integrity sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA==
 
-"@rollup/rollup-android-arm-eabi@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.37.0.tgz#9bedc746a97fe707154086365f269ced92ff4aa9"
-  integrity sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==
-
-"@rollup/rollup-android-arm64@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.37.0.tgz#6edc6ffc8af8773e4bc28c72894dd5e846b8ee6c"
-  integrity sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==
-
 "@rollup/rollup-darwin-arm64@4.37.0":
   version "4.37.0"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.37.0.tgz"
   integrity sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==
-
-"@rollup/rollup-darwin-x64@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.37.0.tgz#a6a697bb685ca9462a7caeea5f22f6a686acff1f"
-  integrity sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==
-
-"@rollup/rollup-freebsd-arm64@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.37.0.tgz#18113e8e133ccb6de4b9dc9d3e09f7acff344cb7"
-  integrity sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==
-
-"@rollup/rollup-freebsd-x64@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.37.0.tgz#5e56ffd4a0d7ccfcbc86867c40b8f0e6a2c0c81e"
-  integrity sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.37.0.tgz#5addf1a51e1495ae7ff28d26442a88adf629c980"
-  integrity sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==
-
-"@rollup/rollup-linux-arm-musleabihf@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.37.0.tgz#00cddb9ab51086c5f2cd33cd4738259e24be4e73"
-  integrity sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==
-
-"@rollup/rollup-linux-arm64-gnu@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.37.0.tgz#c3b4324496236b6fd9f31fda5701c6d6060b1512"
-  integrity sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==
-
-"@rollup/rollup-linux-arm64-musl@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.37.0.tgz#b5222180bb1a50e6e9bc8263efd771c1ce770b6f"
-  integrity sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==
-
-"@rollup/rollup-linux-loongarch64-gnu@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.37.0.tgz#5660181c1c1efb7b19c7a531d496e685236c5ce7"
-  integrity sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==
-
-"@rollup/rollup-linux-powerpc64le-gnu@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.37.0.tgz#8273166495d2f5d3fbc556cf42a5a6e24b78bdab"
-  integrity sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==
-
-"@rollup/rollup-linux-riscv64-gnu@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.37.0.tgz#9677e39288ccc91ebcd707cdd794732d701cd174"
-  integrity sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==
-
-"@rollup/rollup-linux-riscv64-musl@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.37.0.tgz#71cc5ca7be1ed263357618bfe4f8f50c09725a7e"
-  integrity sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==
-
-"@rollup/rollup-linux-s390x-gnu@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.37.0.tgz#6b0b7df33eb32b0ee7423898b183acc1b5fee33e"
-  integrity sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==
-
-"@rollup/rollup-linux-x64-gnu@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz#52c27717d3c4819d13b5ebc2373ddea099d2e71b"
-  integrity sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==
-
-"@rollup/rollup-linux-x64-musl@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.37.0.tgz#c134a22d30642345de8b799c816345674bf68019"
-  integrity sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==
-
-"@rollup/rollup-win32-arm64-msvc@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.37.0.tgz#8063d5f8195dd1845e056d069366fbe06a424d09"
-  integrity sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==
-
-"@rollup/rollup-win32-ia32-msvc@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.37.0.tgz#891d90e3b5517f9d290bb416afdfe2ebfb12139e"
-  integrity sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==
-
-"@rollup/rollup-win32-x64-msvc@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.37.0.tgz#a54d7304c3bd45573d8bcd1270de89771f8195fe"
-  integrity sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==
 
 "@testing-library/dom@^10.4.0":
   version "10.4.0"
@@ -339,15 +124,15 @@
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz"
   integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
-"@types/estree@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
-  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
-
 "@types/estree@^1.0.0":
   version "1.0.7"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
+
+"@types/estree@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
+  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
 "@vitest/expect@3.0.9":
   version "3.0.9"
@@ -368,7 +153,7 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.0.9", "@vitest/pretty-format@^3.0.9":
+"@vitest/pretty-format@^3.0.9", "@vitest/pretty-format@3.0.9":
   version "3.0.9"
   resolved "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz"
   integrity sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==
@@ -430,7 +215,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-aria-query@5.3.0, aria-query@^5.0.0:
+aria-query@^5.0.0, aria-query@5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz"
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
@@ -532,7 +317,7 @@ data-urls@^5.0.0:
     whatwg-mimetype "^4.0.0"
     whatwg-url "^14.0.0"
 
-debug@4, debug@^4.3.4, debug@^4.4.0:
+debug@^4.3.4, debug@^4.4.0, debug@4:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -776,7 +561,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-jsdom@^26.0.0:
+jsdom@*, jsdom@^26.0.0:
   version "26.0.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.0.0.tgz"
   integrity sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==
@@ -805,7 +590,7 @@ jsdom@^26.0.0:
 
 leaflet@^1.9.4:
   version "1.9.4"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
+  resolved "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz"
   integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
 
 lodash@^4.17.21:


### PR DESCRIPTION
## Description
This PR adds an in browser rendered map to show the sender and receiver destinations of the shipment.

## Approach Taken
Augements the show page with a new stimulus controller. Additionally, adds a couple new columns to the shipment model to track the longitude and latitude of the sender and reciever addresses.

## What Could Go Wrong?
Nothing major. No blocking issues could arise. I haven't done comprehensive browser testing yet, but there may be some compatibility issues with legacy and less used browsers. Additionally, it's important to note the the the migrations within this PR are idempotent, so no issues with corrupted data!

## Remediation Strategy 
No serious user impacting issues could arise. 
