### PR TITLE
XMDEV-283: Updates all tables to show addresses instead of names

### DIFF
--- a/app/views/deliveries/index.html.erb
+++ b/app/views/deliveries/index.html.erb
@@ -9,8 +9,8 @@
       <th></th>
       <th>Status</th>
       <th>Name</th>
-      <th>Sender</th>
-      <th>Receiver</th>
+      <th>Sender Address</th>
+      <th>Receiver Address</th>
       <th>Weight</th>
       <th></th>
     </tr>
@@ -21,8 +21,8 @@
       <td><%= check_box_tag 'shipment_ids[]', shipment.id %></td>
       <td><%= shipment.status %></td>
       <td><%= shipment.name %></td>
-      <td><%= shipment.sender_name %></td>
-      <td><%= shipment.receiver_name %></td>
+      <td><%= shipment.sender_address %></td>
+      <td><%= shipment.receiver_address %></td>
       <td><%= shipment.weight %></td>
       <td>
         <%= link_to 'Show Details', shipment, class: 'action-link' %>
@@ -45,8 +45,8 @@
     <tr>
       <th>Status</th>
       <th>Name</th>
-      <th>Sender</th>
-      <th>Receiver</th>
+      <th>Sender Address</th>
+      <th>Receiver Address</th>
       <th>Weight</th>
       <th></th>
     </tr>
@@ -56,8 +56,8 @@
     <tr>
       <td><%= shipment.status %></td>
       <td><%= shipment.name %></td>
-      <td><%= shipment.sender_name %></td>
-      <td><%= shipment.receiver_name %></td>
+      <td><%= shipment.sender_address %></td>
+      <td><%= shipment.receiver_address %></td>
       <td><%= shipment.weight %></td>
       <td>
         <%= link_to 'Show', shipment, class: 'action-link' %> |

--- a/app/views/deliveries/load_truck.html.erb
+++ b/app/views/deliveries/load_truck.html.erb
@@ -17,8 +17,8 @@
       <th></th>
       <th>Status</th>
       <th>Name</th>
-      <th>Sender</th>
-      <th>Receiver</th>
+      <th>Sender Address</th>
+      <th>Receiver Address</th>
       <th>Weight</th>
       <th>Actions</th>
     </tr>
@@ -29,8 +29,8 @@
       <td><%= check_box_tag 'shipment_ids[]', shipment.id %></td>
       <td><%= shipment.status %></td>
       <td><%= shipment.name %></td>
-      <td><%= shipment.sender_name %></td>
-      <td><%= shipment.receiver_name %></td>
+      <td><%= shipment.sender_address %></td>
+      <td><%= shipment.receiver_address %></td>
       <td><%= shipment.weight %></td>
       <td>
         <%= link_to 'Show', shipment, class: 'action-link' %> |

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -33,8 +33,8 @@
         <th>Company</th>
         <th>Status</th>
         <th>Name</th>
-        <th>Sender</th>
-        <th>Receiver</th>
+        <th>Sender Address</th>
+        <th>Receiver Address</th>
         <th>Weight</th>
         <th>Actions</th>
       </tr>
@@ -45,8 +45,8 @@
         <td><%= shipment&.company&.name %></td>
         <td><%= shipment.status %></td>
         <td><%= shipment.name %></td>
-        <td><%= shipment.sender_name %></td>
-        <td><%= shipment.receiver_name %></td>
+        <td><%= shipment.sender_address %></td>
+        <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
         <td>
           <%= link_to 'Quick Close', close_shipment_path(shipment), 

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -9,8 +9,8 @@
       <th>Company</th>
       <th>Status</th>
       <th>Name</th>
-      <th>Sender</th>
-      <th>Receiver</th>
+      <th>Sender Address</th>
+      <th>Receiver Address</th>
       <th>Weight</th>
       <th>Actions</th>
     </tr>
@@ -21,8 +21,8 @@
       <td><%= shipment&.company&.name %></td>
       <td><%= shipment.status %></td>
       <td><%= shipment.name %></td>
-      <td><%= shipment.sender_name %></td>
-      <td><%= shipment.receiver_name %></td>
+      <td><%= shipment.sender_address %></td>
+      <td><%= shipment.receiver_address %></td>
       <td><%= shipment.weight %></td>
       <td>
         <%= link_to 'Show', shipment, class: 'action-link' %> |


### PR DESCRIPTION
## Description
As a trucking professional, the sender and reciever names didn't matter to me as much as the sender and receiver addresses. Therefore, this PR updates the tables accordingly to show the addresses instead.

## Approach Taken
Simple front end change. Updatin' that HTML!

## What Could Go Wrong?
Nothing. Purely cosmetic.

## Remediation Strategy 
NA
