### PR TITLE
XMDEV-285: Adds GHW to prevent accidental merges to main

### DIFF
--- a/.github/workflows/prevent-accidental-main-merge.yml
+++ b/.github/workflows/prevent-accidental-main-merge.yml
@@ -1,0 +1,18 @@
+name: Prevent Main Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if source branch is not a release branch
+        run: |
+          echo "PR branch: ${{ github.head_ref }}"
+          if [[ "${{ github.head_ref }}" != release-* ]]; then
+            echo "Error: Only branches starting with 'release-' can be merged into main."
+            exit 1
+          fi

--- a/.github/workflows/prevent-accidental-main-merge.yml
+++ b/.github/workflows/prevent-accidental-main-merge.yml
@@ -11,8 +11,11 @@ jobs:
     steps:
       - name: Fail if source branch is not a release branch
         run: |
-          echo "PR branch: ${{ github.head_ref }}"
-          if [[ "${{ github.head_ref }}" != release-* ]]; then
+          echo "Source branch: ${{ github.head_ref }}"
+          echo "Target branch: ${{ github.base_ref }}"
+
+          # Only run this check when the target branch is main
+          if [[ "${{ github.base_ref }}" == "main" && "${{ github.head_ref }}" != release-* ]]; then
             echo "Error: Only branches starting with 'release-' can be merged into main."
             exit 1
           fi


### PR DESCRIPTION
## Description
This PR adds a new github workflow that prevents accidental merges of feature branches directly into main. 

## Approach Taken
Created a new github workflow that blocks merges to main unless the source branch begins with `release-*`

## What Could Go Wrong?
This is not a user facing change, therefore no user impact. This is a devex improvement.

## Remediation Strategy 
No need to rollback, if there are errors, simply fix them.
