### PR TITLE
Fix logic for tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'db/migrate/**'
               - 'config/**'
               - 'spec/**'
+              - '!spec/javascripts/**' # Exclude JavaScript specs from backend
               - 'lib/**'
               - 'Gemfile'
               - 'Gemfile.lock'
@@ -49,6 +50,7 @@ jobs:
               - 'app/javascript/**'
               - 'app/assets/**'
               - 'app/views/**'
+              - 'spec/javascripts/**'
               - 'package.json'
               - 'yarn.lock'
               - 'importmap.rb'


### PR DESCRIPTION
## Description
I noticed the other day that adding a spec to the spec/javascripts directory, automatically added the `backend` tag. This is misleading since specs in that folder are for stimulus controllers and javascript functions (frontend dev).

## Approach Taken
Updates the analyze_changes job to exclude changes within the spec/javascripts folder for the backend tag, while adding the folder for the frontend tag.

## What Could Go Wrong?
Unless there is a syntax error, nothing can go wrong for the user. This is a zero risk PR.

## Remediation Strategy 
This is not a user facing change, therefor if issues arise, simply fix them.
