### PR TITLE
XMDEV-284: Updates analyze changes workflow to account for JS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
               - 'db/migrate/**'
               - 'config/**'
               - 'spec/**'
-              - '!spec/javascripts/**' # Exclude JavaScript specs from backend
               - 'lib/**'
               - 'Gemfile'
               - 'Gemfile.lock'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'db/migrate/**'
               - 'config/**'
               - 'spec/**'
+              - '!spec/javascripts/**' # Exclude JavaScript specs from backend
               - 'lib/**'
               - 'Gemfile'
               - 'Gemfile.lock'
@@ -49,6 +50,7 @@ jobs:
               - 'app/javascript/**'
               - 'app/assets/**'
               - 'app/views/**'
+              - 'spec/javascripts/**'
               - 'package.json'
               - 'yarn.lock'
               - 'importmap.rb'

--- a/.github/workflows/prevent-accidental-main-merge.yml
+++ b/.github/workflows/prevent-accidental-main-merge.yml
@@ -9,13 +9,30 @@ jobs:
   check-branch-name:
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if source branch is not a release branch
-        run: |
-          echo "Source branch: ${{ github.head_ref }}"
-          echo "Target branch: ${{ github.base_ref }}"
+      - name: Get current PR information
+        id: get-pr-info
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Get the current PR data
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
 
-          # Only run this check when the target branch is main
-          if [[ "${{ github.base_ref }}" == "main" && "${{ github.head_ref }}" != release-* ]]; then
+            // Set outputs with current source and target branches
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('base_ref', pr.data.base.ref);
+
+      - name: Check if source branch is valid for target
+        run: |
+          echo "Source branch: ${{ steps.get-pr-info.outputs.head_ref }}"
+          echo "Target branch: ${{ steps.get-pr-info.outputs.base_ref }}"
+
+          # Use the fetched branch information
+          if [[ "${{ steps.get-pr-info.outputs.base_ref }}" == "main" && "${{ steps.get-pr-info.outputs.head_ref }}" != release-* ]]; then
             echo "Error: Only branches starting with 'release-' can be merged into main."
             exit 1
           fi


### PR DESCRIPTION
## Description
I noticed the other day that adding a spec to the spec/javascripts directory, automatically added the `backend` tag. This is misleading since specs in that folder are for stimulus controllers and javascript functions (frontend dev).

## Approach Taken
Updates the analyze_changes job to exclude changes within the spec/javascripts folder for the backend tag, while adding the folder for the frontend tag.

## What Could Go Wrong?
Unless there is a syntax error, nothing can go wrong for the user. This is a zero risk PR.

## Remediation Strategy 
This is not a user facing change, therefor if issues arise, simply fix them.
