### PR TITLE
XMDEV-290: Make nullable shipments and deliveries for delivery shipments

### DIFF
--- a/db/migrate/20250503001106_remove_not_null_constraint_from_delivery_shipment_references.rb
+++ b/db/migrate/20250503001106_remove_not_null_constraint_from_delivery_shipment_references.rb
@@ -1,0 +1,38 @@
+class RemoveNotNullConstraintFromDeliveryShipmentReferences < ActiveRecord::Migration[8.0]
+  def up
+    change_column_null(:delivery_shipments, :shipment_id, true) if not_null?(:shipment_id)
+    change_column_null(:delivery_shipments, :delivery_id, true) if not_null?(:delivery_id)
+  end
+
+  def down
+    if DeliveryShipment.where(shipment_id: nil).exists?
+      warn_about_nulls(:shipment_id)
+    else
+      change_column_null(:delivery_shipments, :shipment_id, false)
+    end
+
+    if DeliveryShipment.where(delivery_id: nil).exists?
+      warn_about_nulls(:delivery_id)
+    else
+      change_column_null(:delivery_shipments, :delivery_id, false)
+    end
+  end
+
+  private
+
+  def not_null?(column)
+    !connection.columns(:delivery_shipments).find { |c| c.name == column.to_s }.null
+  end
+
+  def warn_about_nulls(column)
+    puts <<~MSG
+      [MIGRATION WARNING] Cannot re-add NOT NULL constraint to :#{column} on delivery_shipments because NULL values exist.
+      Please clean the data before rerunning this migration.
+    MSG
+  end
+
+  # Define ActiveRecord model inside migration context for safe querying
+  class DeliveryShipment < ActiveRecord::Base
+    self.table_name = 'delivery_shipments'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_02_232749) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_03_001106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -33,8 +33,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_02_232749) do
   end
 
   create_table "delivery_shipments", force: :cascade do |t|
-    t.bigint "delivery_id", null: false
-    t.bigint "shipment_id", null: false
+    t.bigint "delivery_id"
+    t.bigint "shipment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "sender_address"

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -18,10 +18,10 @@ erDiagram
     
     ShipmentStatuses ||--o{ ShipmentActionPreferences : used_in
     
-    Deliveries ||--o{ DeliveryShipments : has
+    Deliveries |o--o{ DeliveryShipments : has
     Deliveries ||--o{ Forms : has
     
-    Shipments ||--o{ DeliveryShipments : included_in
+    Shipments |o--o{ DeliveryShipments : included_in
     
     Companies {
         bigint id PK


### PR DESCRIPTION
## Description
In order to support an upcoming refactor, we need to remove the not null constraint from delivery_shipments in suppose of incremental deliveries.

## Approach Taken
Simple idempotent data migration.

## What Could Go Wrong?
Carries all the risks normally incurred by a schema migration, however, this has been tested and the migrations are idempotent. Additionally, since at the time of writing this PR is creating the not-null constraint there is no impact to user data.

## Remediation Strategy 
Rollback if needed.
