### PR TITLE
XMDEV-287: Removes deleted_at column from shipments and trucks

### DIFF
--- a/db/migrate/20250503004101_remove_deleted_at_columns.rb
+++ b/db/migrate/20250503004101_remove_deleted_at_columns.rb
@@ -1,0 +1,13 @@
+class RemoveDeletedAtColumns < ActiveRecord::Migration[8.0]
+  include MigrationHelpers::IdempotentMigration
+
+  def up
+    remove_column_if_exists :trucks, :deleted_at
+    remove_column_if_exists :shipments, :deleted_at
+  end
+
+  def down
+    add_column_unless_exists :trucks, :deleted_at, :datetime
+    add_column_unless_exists :shipments, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_03_001106) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_03_004101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -100,7 +100,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_001106) do
     t.decimal "length"
     t.decimal "width"
     t.decimal "height"
-    t.datetime "deleted_at"
     t.float "sender_latitude"
     t.float "sender_longitude"
     t.float "receiver_latitude"
@@ -125,7 +124,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_001106) do
     t.decimal "weight"
     t.string "vin", null: false
     t.string "license_plate", null: false
-    t.datetime "deleted_at"
     t.boolean "active", default: false
     t.index ["company_id"], name: "index_trucks_on_company_id"
   end

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -61,7 +61,6 @@ erDiagram
         decimal weight
         string vin
         string license_plate
-        datetime deleted_at
         boolean active
         datetime created_at
         datetime updated_at
@@ -91,7 +90,6 @@ erDiagram
         decimal length
         decimal width
         decimal height
-        datetime deleted_at
         float sender_latitude
         float sender_longitude
         float receiver_latitude


### PR DESCRIPTION
## Description
I noticed that on the shipments and trucks model, there was a deleted_at column which wasn't used. Or added by me anywhere. I am not using the `paranoia` or `discard` gems. I traced the [PR](https://github.com/devxiongmao/truckin-along/pull/188), but as you can see, no migrations touching the truck and shipment tables were in this PR. Possible rails functionality? Whack. Anyway, removing it for cleanup.

## Approach Taken
Simple idempotent data migration to remove the unused columns.

## What Could Go Wrong?
Carries all the risks normally incurred by a schema migration, however, this has been tested and the migrations are idempotent. Additionally, since at the time of writing this PR these columns are not used, there is no user impact risk.

## Remediation Strategy 
Rollback if needed.
