### PR TITLE
XMDEV-295: Removes not null constraint from user_id on the deliveries table

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,5 +1,5 @@
 class Delivery < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :truck
 
   has_many :delivery_shipments, dependent: :nullify

--- a/db/migrate/20250504192431_remove_not_null_from_user_id_on_deliveries.rb
+++ b/db/migrate/20250504192431_remove_not_null_from_user_id_on_deliveries.rb
@@ -1,0 +1,31 @@
+class RemoveNotNullFromUserIdOnDeliveries < ActiveRecord::Migration[8.0]
+  def up
+    change_column_null(:deliveries, :user_id, true) if not_null?(:user_id)
+  end
+
+  def down
+    if Delivery.where(user_id: nil).exists?
+      warn_about_nulls(:user_id)
+    else
+      change_column_null(:deliveries, :user_id, false)
+    end
+  end
+
+  private
+
+  def not_null?(column)
+    !connection.columns(:deliveries).find { |c| c.name == column.to_s }.null
+  end
+
+  def warn_about_nulls(column, table_name)
+    puts <<~MSG
+      [MIGRATION WARNING] Cannot re-add NOT NULL constraint to :#{column} on #{table_name} because NULL values exist.
+      Please clean the data before rerunning this migration.
+    MSG
+  end
+
+  # Define ActiveRecord model inside migration context for safe querying
+  class Delivery < ActiveRecord::Base
+    self.table_name = 'deliveries'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_03_004101) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_04_192431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Delivery, type: :model do
 
   ## Association Tests
   describe "associations" do
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:user).optional }
     it { is_expected.to belong_to(:truck) }
     it { is_expected.to have_many(:delivery_shipments).dependent(:nullify) }
     it { is_expected.to have_many(:shipments).through(:delivery_shipments) }


### PR DESCRIPTION
## Description
In order to support our incremental deliveries feature, we're refactoring the logic for deliveries and thus, needed to update the user_id column to make it nullible. 

## Approach Taken
Wrote an idempotent migration that removes the not null contraint on user_id from the deliveries table. 

## What Could Go Wrong?
Should this change be rollbacked after release, we would need to run a data migration to correct the potentially nil values before doing the rollback. This could be problematic, so it's probably best to consider this an `IrreversibleMigration` and exercise caution before deploying. Confirm the rollout plan, communicate with team members to ensure there are no caveats or gotchas.

## Remediation Strategy 
Rollback if needed.
