### PR TITLE
XMDEV-289: Refactor deliveries to be created on truck load

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -107,7 +107,7 @@ class ShipmentsController < ApplicationController
     service = ScheduleDelivery.new(params, current_company)
 
     if service.run
-      redirect_to load_truck_deliveries_path, notice: "Shipments successfully assigned to truck #{truck.display_name}."
+      redirect_to load_truck_deliveries_path, notice: "Shipments successfully assigned to truck."
     else
       flash[:alert] = service.errors
       redirect_to load_truck_deliveries_path

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -104,18 +104,13 @@ class ShipmentsController < ApplicationController
 
   def assign_shipments_to_truck
     authorize Shipment
-    truck = Truck.find_by(id: params[:truck_id])
-    shipment_ids = params[:shipment_ids]
+    service = ScheduleDelivery.new(params, current_company)
 
-    preference = current_company.shipment_action_preferences.find_by(action: "loaded_onto_truck")
-
-    if truck && shipment_ids.present?
-      shipments = Shipment.for_company(current_company).where(id: shipment_ids)
-      shipments.update_all(truck_id: truck.id)
-      shipments.update_all(shipment_status_id: preference.shipment_status_id) if preference&.shipment_status_id
+    if service.run
       redirect_to load_truck_deliveries_path, notice: "Shipments successfully assigned to truck #{truck.display_name}."
     else
-      redirect_to load_truck_deliveries_path, alert: "Please select a truck and at least one shipment."
+      flash[:alert] = service.errors
+      redirect_to load_truck_deliveries_path
     end
   end
 

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -15,7 +15,7 @@ class Delivery < ApplicationRecord
 
   validates :status, presence: true
 
-  scope :active, -> { where(status: [ :scheduled, :in_progress ]) }
+  scope :active, -> { where(status: :in_progress) }
   scope :inactive, -> { where(status: [ :completed, :cancelled ]) }
   scope :for_user, ->(user) { where(user_id: user.id) }
 

--- a/app/services/initiate_delivery.rb
+++ b/app/services/initiate_delivery.rb
@@ -48,7 +48,7 @@ class InitiateDelivery < ApplicationService
   end
 
   def update_delivery
-    @delivery = Truck.find(@truck_id).active_delivery
+    @delivery = Truck.find(@truck_id).deliveries.scheduled.first
     @delivery.update!({
       user_id: @current_user.id,
       status: :in_progress

--- a/app/services/schedule_delivery.rb
+++ b/app/services/schedule_delivery.rb
@@ -37,7 +37,7 @@ class ScheduleDelivery < ApplicationService
   private
 
   def find_delivery(truck)
-    @delivery = truck.active_delivery
+    @delivery = truck.deliveries.scheduled.first
     return if @delivery.present?
     @delivery = Delivery.create!({
       user_id: nil,
@@ -67,13 +67,13 @@ class ScheduleDelivery < ApplicationService
   end
 
   def load_shipments(shipments)
-    preference = current_company.shipment_action_preferences.find_by(action: "loaded_onto_truck")
+    preference = @current_company.shipment_action_preferences.find_by(action: "loaded_onto_truck")
     if preference&.shipment_status_id
       shipments.each do |shipment|
         shipment.update!(shipment_status_id: preference.shipment_status_id)
       end
     end
-    shipments.update_all(truck_id: truck.id)
+    shipments.update_all(truck_id: @truck_id)
   rescue ActiveRecord::RecordInvalid => e
     @errors << "Failed to update shipment: #{e.message}"
     raise ActiveRecord::Rollback

--- a/app/services/schedule_delivery.rb
+++ b/app/services/schedule_delivery.rb
@@ -1,0 +1,81 @@
+class ScheduleDelivery < ApplicationService
+  attr_reader :errors
+
+  def initialize(params, company)
+    @truck_id = params[:truck_id]
+    @shipment_ids = params[:shipment_ids]
+    @current_company = company
+    @errors = []
+  end
+
+  def run
+    success = false
+
+    ActiveRecord::Base.transaction do
+      truck = Truck.find(@truck_id)
+      unless truck.present?
+        @errors << "Please select a truck."
+        raise ActiveRecord::Rollback
+      end
+
+      find_delivery(truck)
+      shipments = find_shipments
+      if shipments.empty?
+        @errors << "Please select at least one shipment."
+        raise ActiveRecord::Rollback
+      end
+
+      create_delivery_shipments(shipments)
+      load_shipments(shipments)
+
+      success = true
+    end
+
+    success
+  end
+
+  private
+
+  def find_delivery(truck)
+    @delivery = truck.active_delivery
+    return if @delivery.present?
+    @delivery = Delivery.create!({
+      user_id: nil,
+      truck_id: @truck_id,
+      status: :scheduled
+    })
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << "Failed to create delivery: #{e.message}"
+    raise ActiveRecord::Rollback
+  end
+
+  def find_shipments
+    Shipment.for_company(@current_company).where(id: @shipment_ids)
+  end
+
+  def create_delivery_shipments(shipments)
+    shipments.each do |shipment|
+      @delivery.delivery_shipments.create!({
+        shipment: shipment,
+        sender_address: shipment.sender_address,
+        receiver_address: shipment.receiver_address
+      })
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << "Failed to associate shipment: #{e.message}"
+    raise ActiveRecord::Rollback
+  end
+
+  def load_shipments(shipments)
+    preference = current_company.shipment_action_preferences.find_by(action: "loaded_onto_truck")
+    if preference&.shipment_status_id
+      shipments.each do |shipment|
+        shipment.update!(shipment_status_id: preference.shipment_status_id)
+      end
+    end
+    shipments.update_all(truck_id: truck.id)
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << "Failed to update shipment: #{e.message}"
+    raise ActiveRecord::Rollback
+  end
+end

--- a/spec/factories/deliveries.rb
+++ b/spec/factories/deliveries.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :delivery do
     association :truck
     association :user
-    status { :scheduled }
+    status { :in_progress }
   end
 end

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Delivery, type: :model do
     end
 
     describe ".active" do
-      it "includes scheduled and in_progress deliveries" do
-        expect(Delivery.active).to include(@scheduled_delivery, @in_progress_delivery)
-        expect(Delivery.active).not_to include(@completed_delivery, @cancelled_delivery)
+      it "includes in_progress deliveries" do
+        expect(Delivery.active).to include(@in_progress_delivery)
+        expect(Delivery.active).not_to include(@scheduled_delivery, @completed_delivery, @cancelled_delivery)
       end
     end
 

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -858,7 +858,7 @@ RSpec.describe "/shipments", type: :request do
 
         it "shows an alert saying not authorized" do
           post assign_shipments_to_truck_shipments_url, params: { shipment_ids: [], truck_id: nil }
-          expect(flash[:alert]).to eq("Please select a truck and at least one shipment.")
+          expect(flash[:alert]).to eq([ "Please select a truck." ])
         end
       end
 
@@ -880,7 +880,7 @@ RSpec.describe "/shipments", type: :request do
 
         it "shows the appropriate alert" do
           post assign_shipments_to_truck_shipments_url, params: { shipment_ids: [ claimed_shipment.id ], truck_id: truck.id }
-          expect(flash[:notice]).to eq("Shipments successfully assigned to truck #{truck.display_name}.")
+          expect(flash[:notice]).to eq("Shipments successfully assigned to truck.")
         end
 
         describe "when a shipment action preference exists" do
@@ -905,7 +905,7 @@ RSpec.describe "/shipments", type: :request do
 
         it "shows an alert saying not authorized" do
           post initiate_delivery_shipments_url, params: { truck_id: nil }
-          expect(flash[:alert]).to eq([ "Failed to create delivery: Validation failed: Truck must exist" ])
+          expect(flash[:alert]).to eq([ "Please select a truck." ])
         end
       end
 
@@ -924,6 +924,7 @@ RSpec.describe "/shipments", type: :request do
 
       context "with valid params" do
         let(:truck) { create(:truck, company: company) }
+        let!(:delivery) { create(:delivery, truck_id: truck.id, status: :scheduled) }
         let!(:sample_shipment) { create(:shipment, company: company, truck: truck) }
 
         before do

--- a/spec/services/initiate_delivery_spec.rb
+++ b/spec/services/initiate_delivery_spec.rb
@@ -1,42 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe InitiateDelivery, type: :service do
-  let(:user) { create(:user) }
   let(:company) { create(:company) }
+  let(:user) { create(:user) }
   let(:truck) { create(:truck, company: company) }
   let(:open_status) { create(:shipment_status, closed: false) }
   let(:new_status) { create(:shipment_status, closed: true) }
-  let(:closed_status) { create(:shipment_status, closed: true) }
 
-  let(:shipment1) { create(:shipment, truck: truck, company: company, shipment_status: open_status) }
-  let(:shipment2) { create(:shipment, truck: truck, company: company, shipment_status: open_status) }
-  let(:closed_shipment) { create(:shipment, truck: truck, company: company, shipment_status: closed_status) }
+  let!(:shipment1) { create(:shipment, truck: truck, company: company, shipment_status: open_status) }
+  let!(:shipment2) { create(:shipment, truck: truck, company: company, shipment_status: open_status) }
+
+  let!(:preference) { create(:shipment_action_preference, company: company, action: "out_for_delivery", shipment_status: new_status) }
+
+  let!(:delivery) { create(:delivery, truck: truck, status: :scheduled) }
+
   let(:params) { { truck_id: truck.id } }
-
   subject { described_class.new(params, user, company) }
 
   describe "#run" do
-    context "when there are open shipments" do
-      before do
-        shipment1
-        shipment2
+    context "with valid inputs" do
+      it "returns true" do
+        expect(subject.run).to be true
       end
 
-      it "creates a delivery" do
-        expect { subject.run }.to change(Delivery, :count).by(1)
-      end
-
-      it "creates a form" do
-        expect { subject.run }.to change(Form, :count).by(1)
-      end
-
-      it "associates shipments with the delivery" do
+      it "updates the delivery" do
         subject.run
-        expect(subject.delivery.shipments).to match_array([ shipment1, shipment2 ])
+        expect(delivery.reload.status).to eq("in_progress")
+        expect(delivery.user_id).to eq(user.id)
       end
 
-      it "updates the shipment statuses" do
-        preference = create(:shipment_action_preference, company: company, action: "out_for_delivery", shipment_status_id: new_status.id)
+      it "creates a pre-delivery inspection form" do
+        expect { subject.run }.to change(Form, :count).by(1)
+        expect(Form.last.form_type).to eq("Pre-delivery Inspection")
+      end
+
+      it "updates shipment statuses" do
         subject.run
         expect(shipment1.reload.shipment_status_id).to eq(new_status.id)
         expect(shipment2.reload.shipment_status_id).to eq(new_status.id)
@@ -44,47 +42,47 @@ RSpec.describe InitiateDelivery, type: :service do
     end
 
     context "when there are no open shipments" do
-      it "does not create a delivery and returns an error" do
-        expect { subject.run }.not_to change(Delivery, :count)
+      before do
+        shipment1.update!(shipment_status: new_status)
+        shipment2.update!(shipment_status: new_status)
+      end
+
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
         expect(subject.errors).to include("No open shipments found for this truck")
       end
     end
 
-    context "when delivery creation fails" do
+    context "when updating delivery fails" do
       before do
-        allow(Delivery).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(Delivery.new))
+        allow_any_instance_of(Delivery).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(delivery))
       end
 
-      it "does not proceed with shipment associations" do
-        expect { subject.run }.not_to change(DeliveryShipment, :count)
-      end
-
-      it "adds an error message" do
-        subject.run
-        expect(subject.errors).to include(/Failed to create delivery/)
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors.first).to match(/Failed to create delivery/)
       end
     end
 
-    context "when associating shipments fails" do
+    context "when form creation fails" do
       before do
-        shipment1
-        shipment2
+        allow(Form).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(Form.new))
       end
-      let(:delivery_shipments_double) { double('delivery_shipments') }
 
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors.first).to match(/Failed to create Pre delivery inspection form/)
+      end
+    end
+
+    context "when shipment status update fails" do
       before do
-        allow_any_instance_of(Delivery).to receive(:delivery_shipments).and_return(delivery_shipments_double)
-        allow(delivery_shipments_double).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(DeliveryShipment.new))
+        allow_any_instance_of(Shipment).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(Shipment.new))
       end
 
-
-      it "does not update shipment statuses" do
-        expect { subject.run }.not_to change { shipment1.reload.shipment_status_id }
-      end
-
-      it "adds an error message" do
-        subject.run
-        expect(subject.errors).to include(/Failed to associate shipment/)
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors.first).to match(/Failed to update shipment status/)
       end
     end
   end

--- a/spec/services/schedule_delivery_spec.rb
+++ b/spec/services/schedule_delivery_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe ScheduleDelivery, type: :service do
+  let(:company) { create(:company) }
+  let(:truck) { create(:truck, company: company) }
+  let(:shipment_status) { create(:shipment_status, closed: false) }
+  let(:new_status) { create(:shipment_status, closed: false) }
+
+  let!(:shipment1) { create(:shipment, truck: nil, company: company, shipment_status: shipment_status) }
+  let!(:shipment2) { create(:shipment, truck: nil, company: company, shipment_status: shipment_status) }
+
+  let(:params) { { truck_id: truck.id, shipment_ids: [ shipment1.id, shipment2.id ] } }
+
+  subject { described_class.new(params, company) }
+
+  describe "#run" do
+    context "with valid input" do
+      before do
+        create(:shipment_action_preference, company: company, action: "loaded_onto_truck", shipment_status: new_status)
+      end
+
+      it "creates a delivery if one does not exist" do
+        expect { subject.run }.to change(Delivery, :count).by(1)
+      end
+
+      it "reuses existing scheduled delivery if one exists" do
+        create(:delivery, truck: truck, status: :scheduled)
+        expect { subject.run }.not_to change(Delivery, :count)
+      end
+
+      it "associates shipments with the delivery" do
+        subject.run
+        delivery = truck.deliveries.scheduled.first
+        expect(delivery.delivery_shipments.count).to eq(2)
+      end
+
+      it "updates shipment statuses and assigns truck" do
+        subject.run
+        expect(shipment1.reload.truck).to eq(truck)
+        expect(shipment1.shipment_status).to eq(new_status)
+      end
+
+      it "returns true" do
+        expect(subject.run).to eq(true)
+      end
+    end
+
+    context "when truck is not found" do
+      let(:params) { { truck_id: 0, shipment_ids: [ shipment1.id ] } }
+
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors).to include("Please select a truck.")
+      end
+    end
+
+    context "when no shipments are found" do
+      let(:params) { { truck_id: truck.id, shipment_ids: [] } }
+
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors).to include("Please select at least one shipment.")
+      end
+    end
+
+    context "when delivery creation fails" do
+      before do
+        allow(Delivery).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(Delivery.new))
+      end
+
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors.first).to match(/Failed to create delivery/)
+      end
+    end
+
+    context "when shipment association fails" do
+      before do
+        allow_any_instance_of(Delivery).to receive(:delivery_shipments).and_raise(ActiveRecord::RecordInvalid.new(DeliveryShipment.new))
+      end
+
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors.first).to match(/Failed to associate shipment/)
+      end
+    end
+
+    context "when shipment update fails" do
+      before do
+        create(:shipment_action_preference, company: company, action: "loaded_onto_truck", shipment_status_id: new_status.id)
+        allow_any_instance_of(Shipment).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(Shipment.new))
+      end
+
+      it "returns false and adds an error" do
+        expect(subject.run).to eq(false)
+        expect(subject.errors.first).to match(/Failed to update shipment/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR is a backend refactor for how deliveries are managed. This makes the delivery object created when shipments are first loaded onto the truck, along with all delivery_shipments. 

## Approach Taken
Refactoring! Moved the creation logic out of InitiateDelivery and into a new service called ScheduleDelivery. Achieved feature parity so existing users shouldn't notice a different.

## What Could Go Wrong?
For some trucks that have shipments loaded onto them, but don't have deliveries yet, this may cause an issue. However, since we operate in release deployments to prod, this risk is mitigated.

## Remediation Strategy 
Rollback if needed