### PR TITLE
XMDEV-297: Ensures scan_js, lint and scan_ruby jobs are passing before creating a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
   scan_ruby:
     runs-on: ubuntu-latest
     needs: analyze_changes
-    if: needs.analyze_changes.outputs.backend_changes == 'true'
+    if: needs.analyze_changes.outputs.backend_changes == 'true' || startsWith(github.head_ref, 'release-')
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -165,7 +165,7 @@ jobs:
   scan_js:
     runs-on: ubuntu-latest
     needs: analyze_changes
-    if: needs.analyze_changes.outputs.frontend_changes == 'true'
+    if: needs.analyze_changes.outputs.frontend_changes == 'true' || startsWith(github.head_ref, 'release-')
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -204,7 +204,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: analyze_changes
-    if: needs.analyze_changes.outputs.backend_changes == 'true'
+    if: needs.analyze_changes.outputs.backend_changes == 'true' || startsWith(github.head_ref, 'release-')
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -313,7 +313,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [test, test_js]
+    needs: [test, test_js, scan_ruby, scan_js, lint]
     if: startsWith(github.head_ref, 'release-') && success()
     permissions:
       contents: write


### PR DESCRIPTION
## Description
I noticed that on a release creation, the lint, scan_js and scan_ruby jobs were not included in the successful pass check in order for the create_release job to run. Naturally, creating a release is a precursor for deploying to prod, so we want ALL jobs to be passing in order for the release to be created.

## Approach Taken
Updated the github workflow.

## What Could Go Wrong?
Nothing. Not user facing. Zero risk PR.

## Remediation Strategy 
Fix if any issues come up. 
