### PR TITLE
XMDEV-301: Fixes bug showing wrong number of shipments on deliveries start page

### DIFF
--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -36,6 +36,6 @@ class DeliveriesController < ApplicationController
 
   private
     def set_delivery
-      @delivery = Delivery.for_user(current_user).find(params[:id])
+      @delivery = Delivery.find(params[:id])
     end
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -25,7 +25,7 @@ class Delivery < ApplicationRecord
   end
 
   def can_be_closed?
-    shipments.all? { |shipment| shipment.status.nil? || !shipment.open? } && active?
+    delivery_shipments.all? { |del_ship| !del_ship.delivered_date.nil? } && active?
   end
 
   def volume

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -35,7 +35,7 @@ class Truck < ApplicationRecord
   end
 
   def current_shipments
-    latest_delivery.shipments
+    latest_delivery&.shipments || []
   end
 
   def current_volume

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -35,7 +35,7 @@ class Truck < ApplicationRecord
   end
 
   def current_shipments
-    shipments.select(&:open?)
+    latest_delivery.shipments
   end
 
   def current_volume
@@ -44,5 +44,9 @@ class Truck < ApplicationRecord
 
   def current_weight
     current_shipments.reduce(0.0) { |curr_weight, shipment| curr_weight + shipment.weight }
+  end
+
+  def latest_delivery
+    deliveries.order(created_at: :desc).first
   end
 end

--- a/app/policies/delivery_policy.rb
+++ b/app/policies/delivery_policy.rb
@@ -5,12 +5,19 @@ class DeliveryPolicy < ApplicationPolicy
   # code, beware of possible changes to the ancestors:
   # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
 
+  attr_reader :user, :delivery
+
+  def initialize(user, delivery)
+    @user = user
+    @delivery = delivery
+  end
+
   def index?
     user.admin? || user.driver?
   end
 
   def show?
-    user.admin? || user.driver?
+    (delivery.truck.company == user.company) && (user.admin? || user.driver?)
   end
 
   def close?

--- a/app/policies/delivery_policy.rb
+++ b/app/policies/delivery_policy.rb
@@ -21,7 +21,7 @@ class DeliveryPolicy < ApplicationPolicy
   end
 
   def close?
-    user.admin? || user.driver?
+    (delivery.truck.company == user.company) && (user.admin? || user.driver?)
   end
 
   def load_truck?

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -17,15 +17,19 @@
     <% if @delivery.can_be_closed? %>
     <%= link_to "Mark Complete", close_delivery_path(@delivery), class: 'button primary-button', method: :post, data: { confirm: 'All shipments are successfully closed?' } %>
     <% end %>
+    <% if !@delivery.forms.empty? %>
     <button class="action-link" data-action="click->show-pre-delivery#open">
       Pre-delivery Inspection
     </button>
+    <% end %>
     <%= link_to 'Back', start_deliveries_path, class: 'button secondary-button' %>
   </div>
 
+  <% if !@delivery.forms.empty? %>
   <div id="initiate-modal" class="modal hidden">
     <%= render 'forms/completed_pre_delivery_inspection_form', form: @delivery.forms.first%>
   </div>
+  <% end %>
 
   <table class="styled-table">
     <thead>
@@ -41,7 +45,7 @@
     <tbody>
       <% @delivery.shipments.each do |shipment| %>
       <tr>
-        <td><%= shipment.status || "Delivered" %></td>
+        <td><%= shipment.status %></td>
         <td><%= shipment.name %></td>
         <td><%= shipment.sender_address %></td>
         <td><%= shipment.receiver_address %></td>

--- a/app/views/deliveries/start.html.erb
+++ b/app/views/deliveries/start.html.erb
@@ -22,7 +22,7 @@
         <th>Current Volume</th>
         <th>Current Weight</th>
         <th class="center-text">Available?</th>
-        <th>Actions</>
+        <th class="center-text">Actions</>
       </tr>
     </thead>
     <tbody id="my-shipments">
@@ -39,7 +39,8 @@
           ❌
           <% end %>
         </td>
-        <td>
+        <td class="center-text">
+          <%= link_to 'Delivery', truck.latest_delivery, class: 'action-link' %> |
           <button class="action-link" data-action="click->modal#open" data-modal-truck-id-value="<%= truck.id %>">
             Initiate
           </button>

--- a/spec/factories/delivery_shipments.rb
+++ b/spec/factories/delivery_shipments.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
 
     sender_address { Faker::Address.full_address }
     receiver_address { Faker::Address.full_address }
+    loaded_date { Faker::Time.between(from: 30.days.ago, to: Time.current) }
+    delivered_date { nil }
   end
 end

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -90,8 +90,6 @@ RSpec.describe Delivery, type: :model do
 
   describe "#can_be_closed?" do
     let!(:delivery) { create(:delivery) }
-    let!(:status) { create(:shipment_status, closed: true) }
-    let!(:shipment1) { create(:shipment, shipment_status: status) }
 
     context "when the delivery is already closed" do
       it "returns false" do
@@ -101,10 +99,8 @@ RSpec.describe Delivery, type: :model do
     end
 
     context "when shipments are open" do
-      let!(:open_status) { create(:shipment_status, closed: false) }
-      let!(:shipment2) { create(:shipment, shipment_status: open_status) }
-      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, shipment: shipment1) }
-      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, shipment: shipment2) }
+      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
+      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
 
       it "returns false" do
         expect(delivery.can_be_closed?).to be(false)
@@ -112,11 +108,9 @@ RSpec.describe Delivery, type: :model do
     end
 
     context "when all conditions are met" do
-      let!(:shipment2) { create(:shipment, shipment_status: status) }
-      let!(:shipment3) { create(:shipment, shipment_status: nil) }
-      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, shipment: shipment1) }
-      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, shipment: shipment2) }
-      let!(:delivery_shipment3) { create(:delivery_shipment, delivery: delivery, shipment: shipment3) }
+      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, delivered_date: Time.now) }
+      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, delivered_date: Time.now) }
+      let!(:delivery_shipment3) { create(:delivery_shipment, delivery: delivery, delivered_date: Time.now) }
 
       it "returns true" do
         expect(delivery.can_be_closed?).to be(true)

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -169,12 +169,27 @@ RSpec.describe Truck, type: :model do
   end
 
   describe "#current_shipments" do
-    let!(:delivery) { create(:delivery, truck: valid_truck) }
+    context "when there are delivery shipments" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
 
-    let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
-    let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
-    it "returns the open shipments" do
-      expect(valid_truck.current_shipments).to eq([ delivery_shipment1.shipment, delivery_shipment2.shipment ])
+      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
+      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
+      it "returns the open shipments" do
+        expect(valid_truck.current_shipments).to eq([ delivery_shipment1.shipment, delivery_shipment2.shipment ])
+      end
+    end
+
+    context "when there are no delivery shipments" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+      it "returns an empty array" do
+        expect(valid_truck.current_shipments).to eq([])
+      end
+    end
+
+    context "when there is no delivery" do
+      it "returns an empty array" do
+        expect(valid_truck.current_shipments).to eq([])
+      end
     end
   end
 

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -169,31 +169,41 @@ RSpec.describe Truck, type: :model do
   end
 
   describe "#current_shipments" do
-    let!(:open_status) { create(:shipment_status, closed: false) }
-    let!(:closed_status) { create(:shipment_status, closed: true) }
+    let!(:delivery) { create(:delivery, truck: valid_truck) }
 
-    let!(:shipment1) { create(:shipment, truck: valid_truck, shipment_status: open_status) }
-    let!(:shipment2) { create(:shipment, truck: valid_truck, shipment_status: closed_status) }
+    let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
+    let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
     it "returns the open shipments" do
-      expect(valid_truck.current_shipments).to eq([ shipment1 ])
+      expect(valid_truck.current_shipments).to eq([ delivery_shipment1.shipment, delivery_shipment2.shipment ])
     end
   end
 
   describe "#current_volume" do
-    let!(:shipment_status) { create(:shipment_status, closed: false) }
-    let!(:shipment1) { create(:shipment, truck: valid_truck, shipment_status: shipment_status) }
-    let!(:shipment2) { create(:shipment, truck: valid_truck, shipment_status: shipment_status) }
+    let!(:delivery) { create(:delivery, truck: valid_truck) }
+
+    let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
+    let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
     it "calculates the current volume of the truck bed" do
-      expect(valid_truck.current_volume).to eq(shipment1.volume + shipment2.volume)
+      expect(valid_truck.current_volume).to eq(delivery_shipment1.shipment.volume + delivery_shipment2.shipment.volume)
     end
   end
 
   describe "#current_weight" do
-    let!(:shipment_status) { create(:shipment_status, closed: false) }
-    let!(:shipment1) { create(:shipment, truck: valid_truck, shipment_status: shipment_status) }
-    let!(:shipment2) { create(:shipment, truck: valid_truck, shipment_status: shipment_status) }
+    let!(:delivery) { create(:delivery, truck: valid_truck) }
+
+    let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
+    let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
     it "calculates the current volume of the truck bed" do
-      expect(valid_truck.current_weight).to eq(shipment1.weight + shipment2.weight)
+      expect(valid_truck.current_weight).to eq(delivery_shipment1.shipment.weight + delivery_shipment2.shipment.weight)
+    end
+  end
+
+  describe "#latest_delivery" do
+    let!(:delivery) { create(:delivery, truck: valid_truck) }
+    let!(:delivery2) { create(:delivery, truck: valid_truck) }
+
+    it "returns the latest delivery" do
+      expect(valid_truck.latest_delivery).to eq(delivery2)
     end
   end
 end

--- a/spec/policies/delivery_policy_spec.rb
+++ b/spec/policies/delivery_policy_spec.rb
@@ -1,11 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe DeliveryPolicy, type: :policy do
-  let(:admin) { User.new(role: 'admin') }
-  let(:driver) { User.new(role: 'driver') }
-  let(:customer) { User.new(role: 'customer') }
+  let(:company) { create(:company) }
+  let(:admin) { create(:user, role: "admin", company: company) }
+  let(:driver) { create(:user, role: "driver", company: company) }
+  let(:customer) { create(:user, role: "customer") }
 
-  let(:delivery) { Delivery.new } # Mock delivery object
+  let!(:truck) { create(:truck, company: company) }
+
+  let(:delivery) { create(:delivery, truck: truck) } # Mock delivery object
 
   describe 'permissions' do
     context 'when the user is an admin' do


### PR DESCRIPTION
## Description
On the deliveries start page, the count of active shipments was off. 

## Approach Taken
Updated the policy to show deliveries and updated the backend logic for an instance method tied to truck. Specs were updated accordingly.

## What Could Go Wrong?
This is a bug fix, so technically things are already broken. However, some policies changes were conducted. This is high risk in nature. Additional verification tests were performed.

## Remediation Strategy 
This is a bug fix, however this changes up some backend logic. All cases have been checked and CI is passing.
