### PR TITLE
XMDEV-293: Updates delivery show page to separate delivered vs open shipments

### DIFF
--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -10,6 +10,8 @@ class DeliveriesController < ApplicationController
 
   def show
     authorize @delivery
+    @open_shipments = @delivery.open_shipments
+    @delivered_shipments = @delivery.delivered_shipments
   end
 
   def close

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -35,4 +35,17 @@ class Delivery < ApplicationRecord
   def weight
     shipments.reduce(0.0) { |curr_weight, shipment| curr_weight + shipment.weight }
   end
+
+  def open_shipments
+    shipments
+      .joins(:delivery_shipments)
+      .where(delivery_shipments: { delivery_id: id, delivered_date: nil })
+  end
+
+  def delivered_shipments
+    shipments
+      .joins(:delivery_shipments)
+      .where.not(delivery_shipments: { delivered_date: nil })
+      .where(delivery_shipments: { delivery_id: id })
+  end
 end

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -31,6 +31,7 @@
   </div>
   <% end %>
 
+  <% if !@open_shipments.empty? %>
   <table class="styled-table">
     <thead>
       <tr>
@@ -43,7 +44,7 @@
       </tr>
     </thead>
     <tbody>
-      <% @delivery.shipments.each do |shipment| %>
+      <% @open_shipments.each do |shipment| %>
       <tr>
         <td><%= shipment.status %></td>
         <td><%= shipment.name %></td>
@@ -51,16 +52,46 @@
         <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
         <td>
-          <% if shipment.latest_delivery_shipment.delivered_date.nil? %>
           <%= link_to 'Quick Close', close_shipment_path(shipment), 
             class: 'action-link', 
             method: :post, 
             data: { confirm: 'Was this shipment successfully delivered?' } %> |
-          <% end %>
           <%= link_to 'Show', shipment, class: 'action-link' %>
         </td>
       </tr>
       <% end %>
     </tbody>
   </table>
+  <br />
+  <% end %>
+
+  <% if !@delivered_shipments.empty? %>
+  <h3>Closed Shipments</h3>
+  <table class="styled-table">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Name</th>
+        <th>Sender Address</th>
+        <th>Receiver Address</th>
+        <th>Weight</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @delivered_shipments.each do |shipment| %>
+      <tr>
+        <td><%= shipment.status %></td>
+        <td><%= shipment.name %></td>
+        <td><%= shipment.sender_address %></td>
+        <td><%= shipment.receiver_address %></td>
+        <td><%= shipment.weight %></td>
+        <td>
+          <%= link_to 'Show', shipment, class: 'action-link' %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <% end %>
 </div>

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -160,4 +160,32 @@ RSpec.describe Delivery, type: :model do
       end
     end
   end
+
+  describe "#open_shipments" do
+    let!(:shipment1) { create(:shipment) }
+    let!(:shipment2) { create(:shipment) }
+    let!(:shipment3) { create(:shipment) }
+
+    let!(:del_ship1) { create(:delivery_shipment, delivery: valid_delivery, shipment: shipment1, delivered_date: nil) }
+    let!(:del_ship2) { create(:delivery_shipment, delivery: valid_delivery, shipment: shipment2, delivered_date: 1.day.ago) }
+    let!(:del_ship3) { create(:delivery_shipment, delivery: valid_delivery, shipment: shipment3, delivered_date: nil) }
+
+    it "returns shipments with nil delivered_date for #open_shipments" do
+      expect(valid_delivery.open_shipments).to contain_exactly(shipment1, shipment3)
+    end
+  end
+
+  describe "#delivered_shipments" do
+    let!(:shipment1) { create(:shipment) }
+    let!(:shipment2) { create(:shipment) }
+    let!(:shipment3) { create(:shipment) }
+
+    let!(:del_ship1) { create(:delivery_shipment, delivery: valid_delivery, shipment: shipment1, delivered_date: nil) }
+    let!(:del_ship2) { create(:delivery_shipment, delivery: valid_delivery, shipment: shipment2, delivered_date: 1.day.ago) }
+    let!(:del_ship3) { create(:delivery_shipment, delivery: valid_delivery, shipment: shipment3, delivered_date: nil) }
+
+    it "returns shipments with non-nil delivered_date for #delivered_shipments" do
+      expect(valid_delivery.delivered_shipments).to contain_exactly(shipment2)
+    end
+  end
 end


### PR DESCRIPTION
## Description
This PR solves a problem related to lack of visual distinction of delivered shipments on the deliver show page.

## Approach Taken
Two new instance methods for the delivery model that returns relevant shipments, followed by some HTML updates to do some styling.

## What Could Go Wrong?
Nothing major. At most users may get some data rendering in the wrong place on the page in the event of a catastrophic failure. But chances of that are minimal. 

## Remediation Strategy 
Rollback if needed.
