### PR TITLE
XMDEV-294: Bug fix on start deliveries page showing numbers for closed shipments

### DIFF
--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -47,6 +47,6 @@ class Truck < ApplicationRecord
   end
 
   def latest_delivery
-    deliveries.order(created_at: :desc).first
+    deliveries.active.order(created_at: :desc).first
   end
 end

--- a/app/views/deliveries/start.html.erb
+++ b/app/views/deliveries/start.html.erb
@@ -39,12 +39,18 @@
           ❌
           <% end %>
         </td>
+        <% if !truck.latest_delivery.nil? %>
         <td class="center-text">
           <%= link_to 'Delivery', truck.latest_delivery, class: 'action-link' %> |
           <button class="action-link" data-action="click->modal#open" data-modal-truck-id-value="<%= truck.id %>">
             Initiate
           </button>
         </td>
+        <% else %>
+        <td class="center-text">
+          <%= link_to "Add Shipments", load_truck_deliveries_path, class: "button secondary-button" %>
+        </td>
+        <% end %>
       </tr>
       <% end %>
     </tbody>

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -215,10 +215,10 @@ RSpec.describe Truck, type: :model do
 
   describe "#latest_delivery" do
     let!(:delivery) { create(:delivery, truck: valid_truck) }
-    let!(:delivery2) { create(:delivery, truck: valid_truck) }
+    let!(:delivery2) { create(:delivery, truck: valid_truck, status: :completed) }
 
-    it "returns the latest delivery" do
-      expect(valid_truck.latest_delivery).to eq(delivery2)
+    it "returns the latest active delivery" do
+      expect(valid_truck.latest_delivery).to eq(delivery)
     end
   end
 end


### PR DESCRIPTION
## Description
On the deliveries start page, there was a bug where legacy delivery metrics (current_weight, volume) were being shown. This bug fix updated that to be correct.

## Approach Taken
Added a scope to a query to grab active deliveries.

## What Could Go Wrong?
Nothing major. Adds an additional scope to aide with filtering active deliveries.

## Remediation Strategy 
This is a bug fix. If it causes issues, rollback, but otherwise. Keep it!
