### PR TITLE
XMDEV-300: Adds successfully delivered email functionality

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -95,6 +95,7 @@ class ShipmentsController < ApplicationController
 
     @shipment.latest_delivery_shipment.update!(delivered_date: Time.now)
     @shipment.update!(shipment_status_id: preference.shipment_status_id)
+    SendDeliveryEmailJob.perform_later(@shipment.user.email)
     redirect_to delivery_path(@shipment.active_delivery), notice: "Shipment successfully closed."
   end
 

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -95,7 +95,7 @@ class ShipmentsController < ApplicationController
 
     @shipment.latest_delivery_shipment.update!(delivered_date: Time.now)
     @shipment.update!(shipment_status_id: preference.shipment_status_id)
-    SendDeliveryEmailJob.perform_later(@shipment.user.email)
+    SendDeliveryEmailJob.perform_later(@shipment.id)
     redirect_to delivery_path(@shipment.active_delivery), notice: "Shipment successfully closed."
   end
 

--- a/app/jobs/send_delivery_email_job.rb
+++ b/app/jobs/send_delivery_email_job.rb
@@ -1,0 +1,7 @@
+class SendDeliveryEmailJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id, shipment_id)
+    ShipmentDeliveryMailer.successfully_delivered_email(user_id, shipment_id).deliver_now
+  end
+end

--- a/app/jobs/send_delivery_email_job.rb
+++ b/app/jobs/send_delivery_email_job.rb
@@ -1,7 +1,7 @@
 class SendDeliveryEmailJob < ApplicationJob
   queue_as :default
 
-  def perform(user_id, shipment_id)
-    ShipmentDeliveryMailer.successfully_delivered_email(user_id, shipment_id).deliver_now
+  def perform(shipment_id)
+    ShipmentDeliveryMailer.successfully_delivered_email(shipment_id).deliver_now
   end
 end

--- a/app/mailers/shipment_delivery_mailer.rb
+++ b/app/mailers/shipment_delivery_mailer.rb
@@ -1,0 +1,10 @@
+class ShipmentDeliveryMailer < ApplicationMailer
+  default from: "no-reply@example.com"
+
+  def successfully_delivered_email(user_id, shipment_id)
+    @user = User.find(user_id)
+    @shipment = Shipment.find(shipment_id)
+
+    mail(to: @user.email, subject: "Your package has been delivered!")
+  end
+end

--- a/app/mailers/shipment_delivery_mailer.rb
+++ b/app/mailers/shipment_delivery_mailer.rb
@@ -1,9 +1,10 @@
 class ShipmentDeliveryMailer < ApplicationMailer
   default from: "no-reply@example.com"
 
-  def successfully_delivered_email(user_id, shipment_id)
-    @user = User.find(user_id)
+  def successfully_delivered_email(shipment_id)
     @shipment = Shipment.find(shipment_id)
+
+    @user = @shipment.user
 
     mail(to: @user.email, subject: "Your package has been delivered!")
   end

--- a/app/views/shipment_delivery_mailer/successfully_delivered_email.html.erb
+++ b/app/views/shipment_delivery_mailer/successfully_delivered_email.html.erb
@@ -1,0 +1,38 @@
+<h1>Hello, <%= @user.display_name %>!</h1>
+<p>Your shipment: <%= @shipment.name%> has been successfully delivered to <%= @shipment.receiver_address %>. Thank you for using Truckin' Along!</p>
+
+<h2>Shipment Details</h2>
+<div class="details-container">
+  <p><strong>Name:</strong> <span class="detail-value"><%= @shipment.name %></span></p>
+  <p><strong>Sender Name:</strong> <span class="detail-value"><%= @shipment.sender_name %></span></p>
+  <p><strong>Sender Address:</strong> <span class="detail-value"><%= @shipment.sender_address %></span></p>
+  <p><strong>Receiver Name:</strong> <span class="detail-value"><%= @shipment.receiver_name %></span></p>
+  <p><strong>Receiver Address:</strong> <span class="detail-value"><%= @shipment.receiver_address %></span></p>
+  <p><strong>Weight:</strong> <span class="detail-value"><%= @shipment.weight %> kg</span></p>
+  <p><strong>Length:</strong> <span class="detail-value"><%= @shipment.length %> cm</span></p>
+  <p><strong>Width:</strong> <span class="detail-value"><%= @shipment.width %> cm</span></p>
+  <p><strong>Height:</strong> <span class="detail-value"><%= @shipment.height %> cm</span></p>
+</div>
+
+<table class="styled-table">
+  <thead>
+    <tr>
+      <th>Company</th>
+      <th>Departed From</th>
+      <th>Arriving At</th>
+      <th>Processing Date</th>
+      <th>Delivered Date</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @shipment.delivery_shipments.each do |del_ship| %>
+    <tr>
+      <td><%= @shipment.company&.name || del_ship.delivery&.user.company.name %></td>
+      <td><%= del_ship.sender_address %></td>
+      <td><%= del_ship.receiver_address %></td>
+      <td><%= del_ship.loaded_date&.strftime("%Y-%m-%d") %></td>
+      <td><%= del_ship.delivered_date&.strftime("%Y-%m-%d") %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/spec/jobs/send_delivery_email_job_spec.rb
+++ b/spec/jobs/send_delivery_email_job_spec.rb
@@ -1,0 +1,28 @@
+# spec/jobs/send_delivery_email_job_spec.rb
+require 'rails_helper'
+
+RSpec.describe SendDeliveryEmailJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  let(:shipment) { create(:shipment) }
+
+  it 'enqueues the job with correct arguments' do
+    expect {
+      described_class.perform_later(user.id, shipment.id)
+    }.to have_enqueued_job.with(user.id, shipment.id)
+  end
+
+  it 'calls the mailer with correct arguments and delivers the email' do
+    mail_double = double("Mail", deliver_now: true)
+
+    expect(ShipmentDeliveryMailer)
+      .to receive(:successfully_delivered_email)
+      .with(user.id, shipment.id)
+      .and_return(mail_double)
+
+    perform_enqueued_jobs do
+      described_class.perform_later(user.id, shipment.id)
+    end
+  end
+end

--- a/spec/jobs/send_delivery_email_job_spec.rb
+++ b/spec/jobs/send_delivery_email_job_spec.rb
@@ -4,13 +4,12 @@ require 'rails_helper'
 RSpec.describe SendDeliveryEmailJob, type: :job do
   include ActiveJob::TestHelper
 
-  let(:user) { create(:user) }
   let(:shipment) { create(:shipment) }
 
   it 'enqueues the job with correct arguments' do
     expect {
-      described_class.perform_later(user.id, shipment.id)
-    }.to have_enqueued_job.with(user.id, shipment.id)
+      described_class.perform_later(shipment.id)
+    }.to have_enqueued_job.with(shipment.id)
   end
 
   it 'calls the mailer with correct arguments and delivers the email' do
@@ -18,11 +17,11 @@ RSpec.describe SendDeliveryEmailJob, type: :job do
 
     expect(ShipmentDeliveryMailer)
       .to receive(:successfully_delivered_email)
-      .with(user.id, shipment.id)
+      .with(shipment.id)
       .and_return(mail_double)
 
     perform_enqueued_jobs do
-      described_class.perform_later(user.id, shipment.id)
+      described_class.perform_later(shipment.id)
     end
   end
 end

--- a/spec/mailers/previews/shipment_delivery_mailer_preview.rb
+++ b/spec/mailers/previews/shipment_delivery_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/shipment_delivery_mailer
+class ShipmentDeliveryMailerPreview < ActionMailer::Preview
+  def successfully_delivered_email
+    user = User.first || FactoryBot.create(:user, email: 'preview@example.com')
+    shipment = Shipment.first || FactoryBot.create(:shipment)
+
+    ShipmentDeliveryMailer.successfully_delivered_email(user.id, shipment.id)
+  end
+end

--- a/spec/mailers/shipment_delivery_mailer_spec.rb
+++ b/spec/mailers/shipment_delivery_mailer_spec.rb
@@ -1,0 +1,22 @@
+# spec/mailers/shipment_delivery_mailer_spec.rb
+require "rails_helper"
+
+RSpec.describe ShipmentDeliveryMailer, type: :mailer do
+  describe '#successfully_delivered_email' do
+    let(:user) { create(:user, role: "customer") }
+    let(:shipment) { create(:shipment, user: user) }
+
+    let(:mail) { described_class.successfully_delivered_email(user.id, shipment.id) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Your package has been delivered!')
+      expect(mail.to).to eq([ user.email ])
+      expect(mail.from).to eq([ 'no-reply@example.com' ])
+    end
+
+    it 'assigns the user and shipment properly' do
+      expect(mail.body.encoded).to include(user.display_name)
+      expect(mail.body.encoded).to include(shipment.name)
+    end
+  end
+end

--- a/spec/mailers/shipment_delivery_mailer_spec.rb
+++ b/spec/mailers/shipment_delivery_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ShipmentDeliveryMailer, type: :mailer do
     let(:user) { create(:user, role: "customer") }
     let(:shipment) { create(:shipment, user: user) }
 
-    let(:mail) { described_class.successfully_delivered_email(user.id, shipment.id) }
+    let(:mail) { described_class.successfully_delivered_email(shipment.id) }
 
     it 'renders the headers' do
       expect(mail.subject).to eq('Your package has been delivered!')


### PR DESCRIPTION
## Description
We want customers to be notified when their shipments are delivered. This PR adds an async mailer to send emails once shipments are delivered.

## Approach Taken
Since emails are low-priority functionality in this context, I made use of the sidekiq queues. This PR enqueues a delivery email job once a shipment is closed.

## What Could Go Wrong?
Nothing major. Feature has been tested thoroughly. All specs are passing. 

## Remediation Strategy 
Rollback if needed.
