### PR TITLE
XMDEV-306: Adds styling to emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "sidekiq-cron"
 gem "geocoder"
 
 # CSS Styling for emails
-gem 'premailer-rails'
+gem "premailer-rails"
 
 group :development, :test do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem "sidekiq-cron"
 # Adds gem for geolocation
 gem "geocoder"
 
+# CSS Styling for emails
+gem 'premailer-rails'
+
 group :development, :test do
   gem "pry"
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)
+    css_parser (1.21.1)
+      addressable
     csv (3.3.4)
     date (3.4.1)
     debug (1.10.0)
@@ -166,6 +168,7 @@ GEM
       csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    htmlentities (4.3.4)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -241,6 +244,14 @@ GEM
     pg (1.5.9)
     pp (0.6.2)
       prettyprint
+    premailer (1.27.0)
+      addressable
+      css_parser (>= 1.19.0)
+      htmlentities (>= 4.0.0)
+    premailer-rails (1.12.0)
+      actionmailer (>= 3)
+      net-smtp
+      premailer (~> 1.7, >= 1.7.9)
     prettyprint (0.2.0)
     prism (1.4.0)
     propshaft (1.1.0)
@@ -461,6 +472,7 @@ DEPENDENCIES
   kamal
   parallel_tests
   pg (~> 1.1)
+  premailer-rails
   propshaft
   pry
   puma (>= 5.0)

--- a/app/views/shipment_delivery_mailer/successfully_delivered_email.html.erb
+++ b/app/views/shipment_delivery_mailer/successfully_delivered_email.html.erb
@@ -1,3 +1,55 @@
+<style type="text/css">
+  body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    line-height: 1.6;
+    font-size: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #2c3e50;
+    margin-bottom: 10px;
+  }
+
+  .details-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+
+  .detail-value {
+    color: #336699;
+  }
+
+  .styled-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+  }
+
+  .styled-table th,
+  .styled-table td {
+    border: 1px solid #dddddd;
+    padding: 8px;
+    text-align: left;
+  }
+
+  .styled-table th {
+    background-color: #09e80d;
+    color: #ffffff;
+  }
+
+  .styled-table tr:nth-child(even) {
+    background-color: #f9f9f9;
+  }
+</style>
+
+
 <h1>Hello, <%= @user.display_name %>!</h1>
 <p>Your shipment: <%= @shipment.name%> has been successfully delivered to <%= @shipment.receiver_address %>. Thank you for using Truckin' Along!</p>
 

--- a/spec/mailers/previews/shipment_delivery_mailer_preview.rb
+++ b/spec/mailers/previews/shipment_delivery_mailer_preview.rb
@@ -1,9 +1,8 @@
 # Preview all emails at http://localhost:3000/rails/mailers/shipment_delivery_mailer
 class ShipmentDeliveryMailerPreview < ActionMailer::Preview
   def successfully_delivered_email
-    user = User.first || FactoryBot.create(:user, email: 'preview@example.com')
     shipment = Shipment.first || FactoryBot.create(:shipment)
 
-    ShipmentDeliveryMailer.successfully_delivered_email(user.id, shipment.id)
+    ShipmentDeliveryMailer.successfully_delivered_email(shipment.id)
   end
 end


### PR DESCRIPTION
## Description
We want pretty emails.

## Approach Taken
Adds the premailer gem which converts CSS styling to inline styling for emails.

## What Could Go Wrong?
Nothing major. Primarily a cosmetic change for email styling.

## Remediation Strategy 
Rollback if needed, but change of issue is low.
