### PR TITLE
XMDEV-225: Refactors forms to support polymorphic associations.

### DIFF
--- a/app/controllers/trucks_controller.rb
+++ b/app/controllers/trucks_controller.rb
@@ -54,9 +54,10 @@ class TrucksController < ApplicationController
     form = Form.new(form_params.merge(
       user_id: current_user.id,
       company_id: current_company.id,
-      truck_id: @truck.id,
       form_type: "Maintenance",
-      submitted_at: Time.current
+      submitted_at: Time.current,
+      formable_type: "Truck",
+      formable_id: @truck.id
     ))
 
     if form.save

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -4,7 +4,8 @@ class Delivery < ApplicationRecord
 
   has_many :delivery_shipments, dependent: :nullify
   has_many :shipments, through: :delivery_shipments
-  has_many :forms, dependent: :nullify
+
+  has_many :forms, as: :formable
 
   enum :status, {
     scheduled: 0,

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,8 +1,7 @@
 class Form < ApplicationRecord
   belongs_to :user
   belongs_to :company
-  belongs_to :truck, optional: true
-  belongs_to :delivery, optional: true
+  belongs_to :formable, polymorphic: true, optional: true
 
   # Common Validations
   validates :user_id, presence: true

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -3,7 +3,8 @@ class Truck < ApplicationRecord
 
   has_many :shipments, dependent: :nullify
   has_many :deliveries, dependent: :nullify
-  has_many :forms, dependent: :nullify
+
+  has_many :forms, as: :formable
 
   validates :make, :model, :weight, :length, :width, :height, presence: true
   validates :weight, :length, :width, :height, numericality: { greater_than: 0 }

--- a/app/services/initiate_delivery.rb
+++ b/app/services/initiate_delivery.rb
@@ -34,11 +34,11 @@ class InitiateDelivery < ApplicationService
     @form = Form.create!({
       user_id: @current_user.id,
       company_id: @current_company.id,
-      truck_id: @truck_id,
-      delivery_id: @delivery.id,
       title: "Pre Delivery Inspection",
       form_type: "Pre-delivery Inspection",
       submitted_at: Time.now,
+      formable_type: "Delivery",
+      formable_id: @delivery.id,
       content: {
         start_time: Time.now
       }

--- a/db/migrate/20250510205956_change_form_references_to_polymorphic.rb
+++ b/db/migrate/20250510205956_change_form_references_to_polymorphic.rb
@@ -1,0 +1,7 @@
+class ChangeFormReferencesToPolymorphic < ActiveRecord::Migration[8.0]
+  def change
+    unless column_exists?(:forms, :formable_type) && column_exists?(:forms, :formable_id)
+      add_reference :forms, :formable, polymorphic: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_06_000047) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_10_205956) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -60,8 +60,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_06_000047) do
     t.datetime "updated_at", null: false
     t.bigint "truck_id"
     t.bigint "delivery_id"
+    t.string "formable_type"
+    t.bigint "formable_id"
     t.index ["company_id"], name: "index_forms_on_company_id"
     t.index ["delivery_id"], name: "index_forms_on_delivery_id"
+    t.index ["formable_type", "formable_id"], name: "index_forms_on_formable"
     t.index ["truck_id"], name: "index_forms_on_truck_id"
     t.index ["user_id"], name: "index_forms_on_user_id"
   end

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -139,6 +139,8 @@ erDiagram
         bigint company_id FK
         bigint truck_id FK
         bigint delivery_id FK
+        string formable_type
+        bigint formable_id
         string title
         string form_type
         jsonb content

--- a/lib/tasks/backfill_formable.rake
+++ b/lib/tasks/backfill_formable.rake
@@ -1,0 +1,37 @@
+namespace :forms do
+  desc "Backfill formable_type and formable_id with batching and logging"
+  task backfill_formable: :environment do
+    batch_size = 500
+    total_updated = 0
+    start_time = Time.current
+
+    puts "[#{start_time}] Starting backfill of formable..."
+
+    Form.find_in_batches(batch_size: batch_size) do |forms|
+      Form.transaction do
+        forms.each do |form|
+          formable_type = nil
+          formable_id = nil
+
+          if form.delivery_id.present?
+            formable_type = "Delivery"
+            formable_id = form.delivery_id
+          elsif form.truck_id.present?
+            formable_type = "Truck"
+            formable_id = form.truck_id
+          end
+
+          if formable_type && formable_id
+            form.update_columns(formable_type: formable_type, formable_id: formable_id)
+            total_updated += 1
+          end
+        end
+      end
+
+      puts "[#{Time.current}] Processed batch of #{forms.size}, total updated: #{total_updated}"
+    end
+
+    end_time = Time.current
+    puts "[#{end_time}] Backfill complete! Total forms updated: #{total_updated} (Duration: #{end_time - start_time}s)"
+  end
+end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -2,16 +2,25 @@ FactoryBot.define do
   factory :form do
     association :user
     association :company
-    association :truck
-    association :delivery
-
     title { Faker::Lorem.sentence(word_count: 3) }
     form_type { "Maintenance" } # Default to "Maintenance" unless overridden
     submitted_at { Faker::Time.between(from: 30.days.ago, to: Time.current) }
 
+    # Default formable association (will be overridden by traits)
+    # By default, associate with a truck for maintenance forms
+    after(:build) do |form, evaluator|
+      if form.formable.nil?
+        truck = evaluator.formable || create(:truck)
+        form.formable = truck
+        form.formable_type = "Truck"
+        form.formable_id = truck.id
+      end
+    end
+
     # Transient attribute to allow passing custom content without overwriting defaults
     transient do
       custom_content { {} }
+      formable { nil }
     end
 
     # ✅ Pre-Delivery Form
@@ -21,6 +30,14 @@ FactoryBot.define do
         {
           "start_time" => Faker::Time.between(from: 3.days.ago, to: Time.current)
         }.merge(custom_content) # Merge user overrides
+      end
+
+      # Set formable to a delivery
+      after(:build) do |form, evaluator|
+        delivery = evaluator.formable || create(:delivery)
+        form.formable = delivery
+        form.formable_type = "Delivery"
+        form.formable_id = delivery.id
       end
     end
 
@@ -37,6 +54,14 @@ FactoryBot.define do
           "notes" => Faker::Lorem.sentence
         }.merge(custom_content) # Merge user overrides
       end
+
+      # Set formable to a truck
+      after(:build) do |form, evaluator|
+        truck = evaluator.formable || create(:truck)
+        form.formable = truck
+        form.formable_type = "Truck"
+        form.formable_id = truck.id
+      end
     end
 
     # ✅ Delivery Form
@@ -52,6 +77,14 @@ FactoryBot.define do
           ]
         }.merge(custom_content)
       end
+
+      # Set formable to a delivery
+      after(:build) do |form, evaluator|
+        delivery = evaluator.formable || create(:delivery)
+        form.formable = delivery
+        form.formable_type = "Delivery"
+        form.formable_id = delivery.id
+      end
     end
 
     # ✅ Hazmat Form
@@ -66,6 +99,15 @@ FactoryBot.define do
           ],
           "inspection_passed" => Faker::Boolean.boolean
         }.merge(custom_content)
+      end
+
+      # Set formable to a truck (assuming hazmat forms are associated with trucks)
+      # Change this if hazmat forms should be associated with something else
+      after(:build) do |form, evaluator|
+        truck = evaluator.formable || create(:truck)
+        form.formable = truck
+        form.formable_type = "Truck"
+        form.formable_id = truck.id
       end
     end
   end

--- a/spec/jobs/deactivate_trucks_job_spec.rb
+++ b/spec/jobs/deactivate_trucks_job_spec.rb
@@ -5,21 +5,21 @@ RSpec.describe DeactivateTrucksJob, type: :job do
   let!(:truck_recent_inspection) do
     create(:truck, active: true, mileage: 110_000).tap do |truck|
       create(:form, :maintenance,
-             truck: truck,
+             formable: truck,
              custom_content: { "last_inspection_date" => 2.months.ago, "mileage" => 100_000 })
     end
   end
   let!(:truck_old_inspection) do
     create(:truck, active: true, mileage: 150_000).tap do |truck|
       create(:form, :maintenance,
-             truck: truck,
+             formable: truck,
              custom_content: { "last_inspection_date" => 7.months.ago, "mileage" => 125_000 })
     end
   end
   let!(:truck_high_mileage) do
     create(:truck, active: true, mileage: 130_000).tap do |truck|
       create(:form, :maintenance,
-             truck: truck,
+             formable: truck,
              custom_content: { "last_inspection_date" => 3.months.ago, "mileage" => 100_000 })
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe DeactivateTrucksJob, type: :job do
   let!(:truck_edge_case) do
     create(:truck, active: true, mileage: 125_000).tap do |truck|
       create(:form, :maintenance,
-             truck: truck,
+             formable: truck,
              custom_content: { "last_inspection_date" => 6.months.ago.to_date, "mileage" => 100_000 })
     end
   end
@@ -90,7 +90,7 @@ RSpec.describe DeactivateTrucksJob, type: :job do
     it "logs errors when update fails" do
       # Create a scenario where this specific truck should be deactivated
       create(:form, :maintenance,
-             truck: truck_update_error,
+             formable: truck_update_error,
              custom_content: { "last_inspection_date" => 7.months.ago, "mileage" => 150_000 })
 
       allow_any_instance_of(Truck).to receive(:update!).and_call_original

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Delivery, type: :model do
     it { is_expected.to belong_to(:truck) }
     it { is_expected.to have_many(:delivery_shipments).dependent(:nullify) }
     it { is_expected.to have_many(:shipments).through(:delivery_shipments) }
-    it { is_expected.to have_many(:forms).dependent(:nullify) }
+    it { is_expected.to have_many(:forms) }
   end
 
   ## Enum Tests

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -21,8 +21,25 @@ RSpec.describe Form, type: :model do
   describe "associations" do
     it { should belong_to(:user) }
     it { should belong_to(:company) }
-    it { should belong_to(:truck).optional }
-    it { should belong_to(:delivery).optional }
+    it { should belong_to(:formable).optional }
+  end
+
+  describe "polymorphic behavior" do
+    it "can belong to a Truck" do
+      truck = create(:truck)
+      form = create(:form, :maintenance, formable: truck)
+
+      expect(form.formable).to eq(truck)
+      expect(form.formable_type).to eq("Truck")
+    end
+
+    it "can belong to a Delivery" do
+      delivery = create(:delivery)
+      form = create(:form, :pre_delivery, formable: delivery)
+
+      expect(form.formable).to eq(delivery)
+      expect(form.formable_type).to eq("Delivery")
+    end
   end
 
   describe "validations" do

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Truck, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:shipments) }
     it { is_expected.to have_many(:deliveries).dependent(:nullify) }
-    it { is_expected.to have_many(:forms).dependent(:nullify) }
     it { is_expected.to belong_to(:company) }
+    it { is_expected.to have_many(:forms) }
   end
 
   ## Validation Tests

--- a/spec/requests/deliveries_spec.rb
+++ b/spec/requests/deliveries_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "/deliveries", type: :request do
   let!(:other_truck) { create(:truck, company: other_company) }
 
   let!(:delivery) { create(:delivery, user: valid_user, truck: truck, status: :scheduled) }
-  let!(:form) { create(:form, :pre_delivery, delivery: delivery) }
+  let!(:form) { create(:form, :pre_delivery, formable: delivery) }
   let!(:other_delivery) { create(:delivery, user: other_user, truck: other_truck) }
 
   describe "when user is not a customer" do


### PR DESCRIPTION
## Description
Given the upcoming development initiative around updating form types. We wanted to update the form model to support a polymorphic association.

## Approach Taken
Since we have plans to expand out what forms can be linked to, we opted to migrate the relation to a polymorphic association between Deliveries and Trucks currently. This will give us the flexibility later as we onboard more form types.

## What Could Go Wrong?
Care has been taken to write idempotent migrations, and refactor all logic. Code has been thoroughly tested. Deployment plan is as follows: 

1. Deploy this PR
2. Run rake task: `bin/rails forms:backfill_formable`
3. Perform sanity check
4. Let simmer for 2 days
5. Deploy follow up PR removing legacy delivery_id and truck_id foreign keys from the form table

## Remediation Strategy 
Rollback if needed.
