### PR TITLE
XMDEV-313: Bug fix for deliveries show page where scheduled deliveries were not showing

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -16,7 +16,7 @@ class Delivery < ApplicationRecord
 
   validates :status, presence: true
 
-  scope :active, -> { where(status: :in_progress) }
+  scope :active, -> { where(status: [:scheduled, :in_progress]) }
   scope :inactive, -> { where(status: [ :completed, :cancelled ]) }
   scope :for_user, ->(user) { where(user_id: user.id) }
 

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -16,7 +16,7 @@ class Delivery < ApplicationRecord
 
   validates :status, presence: true
 
-  scope :active, -> { where(status: [:scheduled, :in_progress]) }
+  scope :active, -> { where(status: [ :scheduled, :in_progress ]) }
   scope :inactive, -> { where(status: [ :completed, :cancelled ]) }
   scope :for_user, ->(user) { where(user_id: user.id) }
 

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -23,7 +23,7 @@ class Truck < ApplicationRecord
 
   # Check if truck is available
   def available?
-    deliveries.active.none?
+    deliveries.in_progress.none?
   end
 
   # Get the truck's active delivery if any

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Delivery, type: :model do
     end
 
     describe ".active" do
-      it "includes in_progress deliveries" do
-        expect(Delivery.active).to include(@in_progress_delivery)
-        expect(Delivery.active).not_to include(@scheduled_delivery, @completed_delivery, @cancelled_delivery)
+      it "includes scheduled and in_progress deliveries" do
+        expect(Delivery.active).to include(@scheduled_delivery, @in_progress_delivery)
+        expect(Delivery.active).not_to include(@completed_delivery, @cancelled_delivery)
       end
     end
 


### PR DESCRIPTION
## Description
On the deliveries show page, scheduled deliveries were not showing. This was BAD!!!

## Approach Taken
Updated the model instance method.

## What Could Go Wrong?
This changes a core method within the truck model. I don't believe this method is used anywhere else, so this change is relatively small in scope and impact.

## Remediation Strategy 
This is a bug fix. Please do not rollback if you can help it, but if it breaks other functionality, by all means rollback.
