### PR TITLE
XMDEV-312: Removes legacy columns from forms now that forms are polymorphic

### DIFF
--- a/db/migrate/20250510224138_remove_legacy_columns_from_forms.rb
+++ b/db/migrate/20250510224138_remove_legacy_columns_from_forms.rb
@@ -1,0 +1,21 @@
+class RemoveLegacyColumnsFromForms < ActiveRecord::Migration[8.0]
+  def up
+    if column_exists?(:forms, :truck_id)
+      remove_reference :forms, :truck, foreign_key: true
+    end
+
+    if column_exists?(:forms, :delivery_id)
+      remove_reference :forms, :delivery, foreign_key: true
+    end
+  end
+
+  def down
+    unless column_exists?(:forms, :truck_id)
+      add_reference :forms, :truck, foreign_key: true, null: true
+    end
+
+    unless column_exists?(:forms, :delivery_id)
+      add_reference :forms, :delivery, foreign_key: true, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_10_205956) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_10_224138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -58,14 +58,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_10_205956) do
     t.datetime "submitted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "truck_id"
-    t.bigint "delivery_id"
     t.string "formable_type"
     t.bigint "formable_id"
     t.index ["company_id"], name: "index_forms_on_company_id"
-    t.index ["delivery_id"], name: "index_forms_on_delivery_id"
     t.index ["formable_type", "formable_id"], name: "index_forms_on_formable"
-    t.index ["truck_id"], name: "index_forms_on_truck_id"
     t.index ["user_id"], name: "index_forms_on_user_id"
   end
 
@@ -157,8 +153,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_10_205956) do
   add_foreign_key "delivery_shipments", "deliveries"
   add_foreign_key "delivery_shipments", "shipments"
   add_foreign_key "forms", "companies"
-  add_foreign_key "forms", "deliveries"
-  add_foreign_key "forms", "trucks"
   add_foreign_key "forms", "users"
   add_foreign_key "shipment_action_preferences", "companies"
   add_foreign_key "shipment_action_preferences", "shipment_statuses"

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -137,8 +137,6 @@ erDiagram
         bigint id PK
         bigint user_id FK
         bigint company_id FK
-        bigint truck_id FK
-        bigint delivery_id FK
         string formable_type
         bigint formable_id
         string title


### PR DESCRIPTION
## Description
This PR completes the polymorphic forms refactor. This is the cleanup PR that removes the relation from within the database table.

## Approach Taken
Simple migration that removes the legacy columns.

## What Could Go Wrong?
This completely removes the legacy delivery_id and truck_id columns from the Forms table. After this is deployed, we'd need to write another rake task to backfill the data should the need arise. At the time of writing, #278 has been deployed to prod. Mark this PR as closed should we receive any error signal within the next few days.

## Remediation Strategy 
Rollback if needed. 
