### PR TITLE
XMDEV-315: Removes Home Address from Admin driver edit view

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,82 +1,80 @@
 <h2 class="page-title">Edit <%= resource_name.to_s.humanize %></h2>
 
 <% if resource.company %>
-  <div class="form-container">
-    <h2 class="company-name"><%= resource.company.name %></h2>
-    <p class="company-address"><%= resource.company.address %></p>
-    <% if resource.admin? %>
-      <div>
-        <%= link_to 'Edit Company', edit_company_path(resource.company), class: "primary-button" %>
-      </div>
-    <% end %>
+<div class="form-container">
+  <h2 class="company-name"><%= resource.company.name %></h2>
+  <p class="company-address"><%= resource.company.address %></p>
+  <% if resource.admin? %>
+  <div>
+    <%= link_to 'Edit Company', edit_company_path(resource.company), class: "primary-button" %>
   </div>
-  <br />
+  <% end %>
+</div>
+<br />
 <% end %>
 
 <div class="form-container">
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'styled-form' }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="form-group">
-      <%= f.label :first_name, "First Name", class: 'form-label' %>
-      <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
-    </div>
+  <div class="form-group">
+    <%= f.label :first_name, "First Name", class: 'form-label' %>
+    <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :last_name, "Last Name", class: 'form-label' %>
-      <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
-    </div>
+  <div class="form-group">
+    <%= f.label :last_name, "Last Name", class: 'form-label' %>
+    <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :home_address, class: 'form-label'  %>
-      <%= f.text_field :home_address, class: "form-input" %>
-    </div>
+  <div class="form-group">
+    <%= f.label :home_address, class: 'form-label'  %>
+    <%= f.text_field :home_address, class: "form-input" %>
+  </div>
 
-    <% unless resource.role == "customer" %>
-      <div class="form-group">
-        <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
-        <%= f.text_field :drivers_license, class: 'form-input' %>
-      </div>
+  <% unless resource.role == "customer" %>
+  <div class="form-group">
+    <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
+    <%= f.text_field :drivers_license, class: 'form-input' %>
+  </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :email, class: 'form-label' %>
+    <%= f.email_field :email, class: 'form-input', autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+  <div class="info-message">
+    Currently waiting confirmation for: <%= resource.unconfirmed_email %>
+  </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :password, class: 'form-label' %>
+    <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, class: 'form-input', autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+    <small><em><%= @minimum_password_length %> characters minimum</em></small>
     <% end %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :email, class: 'form-label' %>
-      <%= f.email_field :email, class: 'form-input', autofocus: true, autocomplete: "email" %>
-    </div>
+  <div class="form-group">
+    <%= f.label :password_confirmation, "Confirm Password", class: 'form-label' %>
+    <%= f.password_field :password_confirmation, class: 'form-input', autocomplete: "new-password" %>
+  </div>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div class="info-message">
-        Currently waiting confirmation for: <%= resource.unconfirmed_email %>
-      </div>
-    <% end %>
+  <div class="form-group">
+    <%= f.label :current_password, "Current Password", class: 'form-label' %>
+    <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, class: 'form-input', autocomplete: "current-password" %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :password, class: 'form-label' %>
-      <i>(leave blank if you don't want to change it)</i><br />
-      <%= f.password_field :password, class: 'form-input', autocomplete: "new-password" %>
-      <% if @minimum_password_length %>
-        <small><em><%= @minimum_password_length %> characters minimum</em></small>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :password_confirmation, "Confirm Password", class: 'form-label' %>
-      <%= f.password_field :password_confirmation, class: 'form-input', autocomplete: "new-password" %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :current_password, "Current Password", class: 'form-label' %>
-      <i>(we need your current password to confirm your changes)</i><br />
-      <%= f.password_field :current_password, class: 'form-input', autocomplete: "current-password" %>
-    </div>
-
-    <div class="details-actions">
-      <%= f.submit "Update", class: "primary-button" %>
-    </div>
+  <div class="details-actions">
+    <%= f.submit "Update", class: "primary-button" %>
+  </div>
   <% end %>
 </div>
-
-<h3 class="section-title">Cancel my account</h3>
 
 <div class="danger-section">
   <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "danger-button" %></p>

--- a/app/views/driver_managements/_form.html.erb
+++ b/app/views/driver_managements/_form.html.erb
@@ -21,18 +21,8 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :home_address, class: 'form-label'  %>
-  <%= f.text_field :home_address, class: "form-input" %>
-</div>
-
-<div class="form-group">
   <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
   <%= f.text_field :drivers_license, class: 'form-input' %>
-</div>
-
-<div class="form-group">
-  <%= f.label :email, nil, class: 'form-label' %>
-  <%= f.email_field :email, class: 'form-input', required: true %>
 </div>
 
 <div class="actions">

--- a/app/views/driver_managements/new.html.erb
+++ b/app/views/driver_managements/new.html.erb
@@ -5,49 +5,49 @@
 
 <div class="form-container">
   <%= form_with model: @driver, url: driver_managements_path, local: true, class: 'styled-form' do |f| %>
-    <% if @driver.errors.any? %>
-      <div class="error-messages">
-        <h2><%= pluralize(@driver.errors.count, "error") %> prohibited this driver from being saved:</h2>
-        <ul>
-          <% @driver.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+  <% if @driver.errors.any? %>
+  <div class="error-messages">
+    <h2><%= pluralize(@driver.errors.count, "error") %> prohibited this driver from being saved:</h2>
+    <ul>
+      <% @driver.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+  <% end %>
 
-    <div class="form-group">
-      <%= f.label :first_name, "First Name", class: 'form-label' %>
-      <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
-    </div>
+  <div class="form-group">
+    <%= f.label :first_name, "First Name", class: 'form-label' %>
+    <%= f.text_field :first_name, class: 'form-input', autocomplete: "given-name" %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :last_name, "Last Name", class: 'form-label' %>
-      <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
-    </div>
+  <div class="form-group">
+    <%= f.label :last_name, "Last Name", class: 'form-label' %>
+    <%= f.text_field :last_name, class: 'form-input', autocomplete: "family-name" %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
-      <%= f.text_field :drivers_license, class: 'form-input' %>
-    </div>
+  <div class="form-group">
+    <%= f.label :drivers_license, "Driver's License", class: 'form-label' %>
+    <%= f.text_field :drivers_license, class: 'form-input' %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :email, nil, class: 'form-label' %>
-      <%= f.email_field :email, class: 'form-input', required: true %>
-    </div>
+  <div class="form-group">
+    <%= f.label :email, nil, class: 'form-label' %>
+    <%= f.email_field :email, class: 'form-input', required: true %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :password, nil, class: 'form-label' %>
-      <%= f.password_field :password, class: 'form-input', required: true %>
-    </div>
+  <div class="form-group">
+    <%= f.label :password, nil, class: 'form-label' %>
+    <%= f.password_field :password, class: 'form-input', required: true %>
+  </div>
 
-    <div class="form-group">
-      <%= f.label :password_confirmation, "Password Confirmation", class: 'form-label' %>
-      <%= f.password_field :password_confirmation, class: 'form-input', required: true %>
-    </div>
+  <div class="form-group">
+    <%= f.label :password_confirmation, "Password Confirmation", class: 'form-label' %>
+    <%= f.password_field :password_confirmation, class: 'form-input', required: true %>
+  </div>
 
-    <div class="details-actions">
-      <%= f.submit "Create Driver", class: 'primary-button' %>
-    </div>
+  <div class="details-actions">
+    <%= f.submit "Create Driver", class: 'primary-button' %>
+  </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Description
I noticed that Admins could create a driver without a home address, then when they went to edit the driver later, they could manipulate the home address field. This was not the desired behavior. Therefore, this was changed so that an admin could only update the first, last name and drivers license of a user.

## Approach Taken
Simply updated the views so that within the admin -> Driver edit view, the home address wouldn't show.

## What Could Go Wrong?
Purely a cosmetic change on the frontend. No real risk.

## Remediation Strategy 
NA
