### PR TITLE
XMDEV-316: Adds redirect on sign up and login to my dashboard page

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,4 +12,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = User.new(role: "customer")
     render :new
   end
+
+  protected
+
+  def after_sign_in_path_for(resource)
+    dashboard_path
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  protected
+
+  def after_sign_in_path_for(resource)
+    dashboard_path
+  end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: "users/registrations"
+    registrations: "users/registrations",
+    sessions: "users/sessions"
   }
 
   devise_scope :user do

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe "Users::RegistrationsController", type: :request do
         expect(user.role).to eq("admin")
       end
 
-      it "redirects to the root path (default Devise behavior after signup)" do
+      it "redirects to the dashboard path" do
         post user_registration_path, params: { user: valid_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
     end
 

--- a/spec/system/user_authentication_spec.rb
+++ b/spec/system/user_authentication_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "User Authentication", type: :system do
     click_button "Log in"
 
     expect(page).to have_content("Signed in successfully")
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(dashboard_path)
   end
 
   it "rejects invalid credentials" do


### PR DESCRIPTION
## Description
Upon signup, or login, users were redirected to the welcome page (showing signup options and app features). This was inelegant, so we updated it to redirect to the dashboard page.
 
## Approach Taken
Overrides default Devise behaviour by adding custom devise controllers, and customizing the after_sign_in_path_for methods.

## What Could Go Wrong?
Nothing. No real risk here.

## Remediation Strategy 
NA.