### PR TITLE
Redirect after company creation

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -15,7 +15,7 @@ class CompaniesController < ApplicationController
       current_user.save
       setup_company_defaults(@company)
       flash[:notice] = "Company created successfully."
-      redirect_to root_path
+      redirect_to dashboard_path
     else
       flash.now[:alert] = "Failed to create company."
       render :new, status: :unprocessable_entity
@@ -30,7 +30,7 @@ class CompaniesController < ApplicationController
     authorize @company
     if @company.update(company_params)
       flash[:notice] = "Company updated successfully."
-      redirect_to root_path
+      redirect_to dashboard_path
     else
       flash.now[:alert] = "Failed to update company."
       render :edit, status: :unprocessable_entity
@@ -43,7 +43,7 @@ class CompaniesController < ApplicationController
     @company = Company.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     flash[:alert] = "Company not found."
-    redirect_to root_path
+    redirect_to dashboard_path
   end
 
   def company_params

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe "/companies", type: :request do
           expect(valid_user.reload.company).to eq(Company.last)
         end
 
-        it "redirects to the root page" do
+        it "redirects to the dashboard page" do
           post companies_url, params: { company: valid_attributes }
-          expect(response).to redirect_to(root_url)
+          expect(response).to redirect_to(dashboard_url)
         end
 
         it 'renders the correct flash response' do
@@ -144,9 +144,9 @@ RSpec.describe "/companies", type: :request do
       end
 
       context "when the company is not found" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get edit_company_url(99999)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders the correct flash alert' do
@@ -169,9 +169,9 @@ RSpec.describe "/companies", type: :request do
           expect(company.address).to eq("456 Updated Street")
         end
 
-        it "redirects to the edit page for the company" do
+        it "redirects to the dashboard page" do
           patch company_url(company), params: { company: new_attributes }
-          expect(response).to redirect_to(root_url)
+          expect(response).to redirect_to(dashboard_url)
         end
       end
 


### PR DESCRIPTION
## Description
Upon creating a company, the user was redirected to the root page, which was a regression from #300 .

## Approach Taken
Updates the redirect path for the create and update actions within the companies controller.

## What Could Go Wrong?
Nothing major. Simple redirect.

## Remediation Strategy 
NA