### PR TITLE
XMDEV-327: Updates check on empty shipments array to do conditional map render on load truck page

### DIFF
--- a/app/views/deliveries/load_truck.html.erb
+++ b/app/views/deliveries/load_truck.html.erb
@@ -1,9 +1,9 @@
 <h1>Deliveries</h1>
 
+<% if @unassigned_shipments.any? %>
 <div style="height: 500px; width: 100%;" data-controller="show-truck-loading-map" data-show-truck-loading-map-shipments-json-value='<%= raw @unassigned_shipments.to_json(only: [:id], methods: [:sender_latitude, :sender_longitude, :receiver_latitude, :receiver_longitude, :sender_address, :receiver_address]) %>'>
 </div>
 <h2>Truck Loading</h2>
-<% if @unassigned_shipments.any? %>
 <div data-controller="truck-loading-modal">
   <%= form_with url: assign_shipments_to_truck_shipments_path, method: :post, data: { truck_loading_modal_target: "form" } do |f| %>
 


### PR DESCRIPTION
## Description
When there were no shipments available to be loaded onto a truck, the error div for the map render would show. This was confusing to the user since they might be convinced something was wrong.

## Approach Taken
We therefor opted to make it intelligent. If there are shipments, then the map render will show.

## What Could Go Wrong?
Nothing.

## Remediation Strategy 
NA
