### PR TITLE
Async geocode deliveries

### DIFF
--- a/app/jobs/geocode_delivery_shipments_job.rb
+++ b/app/jobs/geocode_delivery_shipments_job.rb
@@ -1,0 +1,27 @@
+class GeocodeDeliveryShipmentsJob < ApplicationJob
+  queue_as :default
+
+  def perform(ids)
+    DeliveryShipment.where(id: ids).find_each do |shipment|
+      updates = {}
+
+      if shipment.sender_address.present?
+        sender_result = Geocoder.search(shipment.sender_address).first
+        if sender_result
+          updates[:sender_latitude] = sender_result.latitude
+          updates[:sender_longitude] = sender_result.longitude
+        end
+      end
+
+      if shipment.receiver_address.present?
+        receiver_result = Geocoder.search(shipment.receiver_address).first
+        if receiver_result
+          updates[:receiver_latitude] = receiver_result.latitude
+          updates[:receiver_longitude] = receiver_result.longitude
+        end
+      end
+
+      shipment.update_columns(updates) if updates.present?
+    end
+  end
+end

--- a/app/services/schedule_delivery.rb
+++ b/app/services/schedule_delivery.rb
@@ -58,7 +58,8 @@ class ScheduleDelivery < ApplicationService
       }
     end
 
-    @delivery.delivery_shipments.insert_all!(shipment_attributes)
+    inserted = @delivery.delivery_shipments.insert_all!(shipment_attributes, returning: %w[id])
+    GeocodeDeliveryShipmentsJob.perform_later(inserted.pluck("id"))
   rescue ActiveRecord::RecordInvalid => e
     @errors << "Failed to associate shipment: #{e.message}"
     raise e

--- a/spec/jobs/geocode_delivery_shipments_job_spec.rb
+++ b/spec/jobs/geocode_delivery_shipments_job_spec.rb
@@ -1,5 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe GeocodeDeliveryShipmentsJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:sender_address) { "1600 Amphitheatre Parkway, Mountain View, CA" }
+  let(:receiver_address) { "1 Infinite Loop, Cupertino, CA" }
+
+  let!(:shipment) do
+    create(:delivery_shipment, sender_address: sender_address, receiver_address: receiver_address)
+  end
+
+  it 'updates coordinates for sender and receiver' do
+    described_class.new.perform([ shipment.id ])
+
+    shipment.reload
+    expect(shipment.sender_latitude).to eq 40.7128
+    expect(shipment.sender_longitude).to eq -74.006
+    expect(shipment.receiver_latitude).to eq 40.7128
+    expect(shipment.receiver_longitude).to eq -74.006
+  end
+
+  it 'raises error if Geocoder fails, triggering Sidekiq retry' do
+    allow(Geocoder).to receive(:search).with(sender_address).and_raise(StandardError.new("Boom"))
+
+    expect {
+      described_class.new.perform([ shipment.id ])
+    }.to raise_error(StandardError)
+  end
+
+  it 'logs and raises when rate limited' do
+    allow(Geocoder).to receive(:search).with(sender_address).and_raise(Geocoder::OverQueryLimitError.new("Rate limit"))
+
+    expect(Rails.logger).to receive(:warn).with(/Rate limited by Geocoder/)
+
+    expect {
+      described_class.new.perform([ shipment.id ])
+    }.to raise_error(Geocoder::OverQueryLimitError)
+  end
 end

--- a/spec/jobs/geocode_delivery_shipments_job_spec.rb
+++ b/spec/jobs/geocode_delivery_shipments_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GeocodeDeliveryShipmentsJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/jobs/geocode_delivery_shipments_job_spec.rb
+++ b/spec/jobs/geocode_delivery_shipments_job_spec.rb
@@ -4,18 +4,16 @@ RSpec.describe GeocodeDeliveryShipmentsJob, type: :job do
   let(:sender_address) { "1600 Amphitheatre Parkway, Mountain View, CA" }
   let(:receiver_address) { "1 Infinite Loop, Cupertino, CA" }
 
-  let!(:shipment) do
-    create(:delivery_shipment, sender_address: sender_address, receiver_address: receiver_address)
-  end
+  let (:delivery_shipment) { create(:delivery_shipment, sender_address: sender_address, receiver_address: receiver_address) }
 
   it 'updates coordinates for sender and receiver' do
-    described_class.new.perform([ shipment.id ])
+    described_class.new.perform([ delivery_shipment.id ])
 
-    shipment.reload
-    expect(shipment.sender_latitude).to eq 40.7128
-    expect(shipment.sender_longitude).to eq -74.006
-    expect(shipment.receiver_latitude).to eq 40.7128
-    expect(shipment.receiver_longitude).to eq -74.006
+    delivery_shipment.reload
+    expect(delivery_shipment.sender_latitude).to eq 40.7128
+    expect(delivery_shipment.sender_longitude).to eq -74.006
+    expect(delivery_shipment.receiver_latitude).to eq 40.7128
+    expect(delivery_shipment.receiver_longitude).to eq -74.006
   end
 
   it 'raises error if Geocoder fails, triggering Sidekiq retry' do
@@ -26,13 +24,11 @@ RSpec.describe GeocodeDeliveryShipmentsJob, type: :job do
     }.to raise_error(StandardError)
   end
 
-  it 'logs and raises when rate limited' do
+  it 'raises when rate limited' do
     allow(Geocoder).to receive(:search).with(sender_address).and_raise(Geocoder::OverQueryLimitError.new("Rate limit"))
 
-    expect(Rails.logger).to receive(:warn).with(/Rate limited by Geocoder/)
-
     expect {
-      described_class.new.perform([ shipment.id ])
+      described_class.new.perform([ delivery_shipment.id ])
     }.to raise_error(Geocoder::OverQueryLimitError)
   end
 end

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -921,6 +921,12 @@ RSpec.describe "/shipments", type: :request do
           expect(flash[:notice]).to eq("Shipments successfully assigned to truck.")
         end
 
+        it "enqueues a geocode job" do
+          expect {
+            post assign_shipments_to_truck_shipments_url, params: { shipment_ids: [ claimed_shipment.id ], truck_id: truck.id }
+          }.to have_enqueued_job(GeocodeDeliveryShipmentsJob)
+        end
+
         describe "when a shipment action preference exists" do
           let(:shipment_status) { create(:shipment_status, company: company) }
           let!(:company_preference) { create(:shipment_action_preference, action: "loaded_onto_truck", company: company, shipment_status: shipment_status) }

--- a/spec/services/schedule_delivery_spec.rb
+++ b/spec/services/schedule_delivery_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe ScheduleDelivery, type: :service do
         expect(delivery.delivery_shipments.last.sender_address).to eq(delivery_shipment.receiver_address)
       end
 
+      it "enqueus a job to geocode delivery shipments" do
+        expect {
+          subject.run
+        }.to have_enqueued_job(GeocodeDeliveryShipmentsJob)
+      end
+
       it "returns true" do
         expect(subject.run).to eq(true)
       end


### PR DESCRIPTION
## Description
We wanted the performance of insert_all when creating delivery shipments, however, insert_all bypasses validations, so we weren't geocoding addresses. This was no bueno.

## Approach Taken
I created an async job that geocodes the addresses behind the scenes! I updated all specs accordingly.

## What Could Go Wrong?
This adds a new async job, so it carries all the risks that come with adding a new job. This has been thoroughly tested and proper logging is in place.

## Remediation Strategy 
Rollback if needed
