### PR TITLE
XMDEV-332: Bug fix for deliveries being able to be marked delivered before delivery was in progress

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -74,6 +74,9 @@ class ShipmentsController < ApplicationController
 
   def close
     authorize Shipment
+    unless @shipment.latest_delivery_shipment.delivery.in_progress?
+      return redirect_to delivery_path(@shipment.active_delivery), alert: "Delivery is not in progress."
+    end
 
     if @shipment.receiver_address != @shipment.latest_delivery_shipment.receiver_address
       @shipment.latest_delivery_shipment.update!(delivered_date: Time.now)

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -13,7 +13,7 @@
 <br />
 <div data-controller="show-pre-delivery">
   <div class="page-header">
-    <h1 class="page-title">Delivery Details</h1>
+    <h1 class="page-title">Delivery Details - <%= @delivery.status.humanize %></h1>
     <% if @delivery.can_be_closed? %>
     <%= link_to "Mark Complete", close_delivery_path(@delivery), class: 'button primary-button', method: :post, data: { confirm: 'All shipments are successfully closed?' } %>
     <% end %>
@@ -52,10 +52,12 @@
         <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
         <td>
+          <% if @delivery.in_progress? %>
           <%= link_to 'Quick Close', close_shipment_path(shipment), 
             class: 'action-link', 
             method: :post, 
             data: { confirm: 'Was this shipment successfully delivered?' } %> |
+          <% end %>
           <%= link_to 'Show', shipment, class: 'action-link' %>
         </td>
       </tr>

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -729,6 +729,21 @@ RSpec.describe "/shipments", type: :request do
       let!(:delivery_shipment) { create(:delivery_shipment, shipment: claimed_shipment, delivery: delivery, receiver_address: claimed_shipment.receiver_address) }
       let!(:shipment_status) { create(:shipment_status, company: company) }
 
+      context "when the delivery is not in_progress" do
+        let!(:delivery) { create(:delivery, status: :scheduled) }
+        let!(:delivery_shipment) { create(:delivery_shipment, shipment: claimed_shipment, delivery: delivery) }
+
+        it "shows the correct alert" do
+          post close_shipment_url(claimed_shipment)
+          expect(flash[:alert]).to eq("Delivery is not in progress.")
+        end
+
+        it "redirects to the delivery show page" do
+          post close_shipment_url(claimed_shipment)
+          expect(response).to redirect_to(delivery_url(claimed_shipment.active_delivery))
+        end
+      end
+
       context "when the receiver address is not the same as within the shipment" do
         let!(:delivery_shipment) { create(:delivery_shipment, shipment: claimed_shipment, delivery: delivery) }
         it "shows the correct notice" do


### PR DESCRIPTION
## Description
There was a bug within the app that allowed shipments to be closed before the delivery was in progress.

## Approach Taken
Updated the front end to remove the button, and added additional security to the backend to prevent the shipment from being closed.

## What Could Go Wrong?
This is a bug fix, so things are already wrong. But this will not introduce issues for our users.

## Remediation Strategy 
NA
