### PR TITLE
XMDEV-323: Adds CloseDelivery service to update delivery and truck

### DIFF
--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -16,12 +16,14 @@ class DeliveriesController < ApplicationController
 
   def close
     authorize @delivery
-    if @delivery.can_be_closed?
-      @delivery.update!(status: :completed)
-      return redirect_to start_deliveries_path, notice: "Delivery complete!"
-    end
 
-    redirect_to delivery_path(@delivery), alert: "Delivery still has open shipments. It cannot be closed at this time."
+    result = DeliveryClosureService.new(@delivery, odometer_params).call
+
+    if result.success?
+      redirect_to start_deliveries_path, notice: result.message
+    else
+      redirect_to delivery_path(@delivery), alert: result.error
+    end
   end
 
   def load_truck
@@ -39,5 +41,9 @@ class DeliveriesController < ApplicationController
   private
     def set_delivery
       @delivery = Delivery.find(params[:id])
+    end
+
+    def odometer_params
+      { odometer_reading: params[:odometer_reading].to_i }
     end
 end

--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -17,7 +17,7 @@ class DeliveriesController < ApplicationController
   def close
     authorize @delivery
 
-    result = DeliveryClosureService.new(@delivery, odometer_params).call
+    result = CloseDelivery.new(@delivery, odometer_params).call
 
     if result.success?
       redirect_to start_deliveries_path, notice: result.message

--- a/app/javascript/controllers/complete_delivery_controller.js
+++ b/app/javascript/controllers/complete_delivery_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="complete-delivery"
+export default class extends Controller {
+  static targets = [
+    "modal", 
+    "confirmBtn", 
+    "cancelBtn", 
+    "form", 
+    "odometerInput", 
+    "odometerContainer"
+  ]
+  
+  connect() {
+    this.modalTarget.style.display = "none"
+    this.odometerContainerTarget.style.display = "none"
+  }
+  
+  showModal(event) {
+    event.preventDefault()
+    
+    // Show modal
+    this.modalTarget.style.display = "flex"
+  }
+  
+  hideModal() {
+    this.modalTarget.style.display = "none"
+    
+    // Reset odometer input if shown
+    this.odometerContainerTarget.style.display = "none"
+    this.odometerInputTarget.value = ""
+  }
+  
+  showOdometerInput() {
+    // Show odometer input field when "Yes" is clicked
+    this.odometerContainerTarget.style.display = "block"
+  }
+  
+  submitWithOdometer() {
+    // Create a hidden input with the new odometer value
+    const odometerInput = document.createElement("input")
+    odometerInput.type = "hidden"
+    odometerInput.name = "odometer_reading"
+    odometerInput.value = this.odometerInputTarget.value
+
+    console.log("Submitting with odometer value:", odometerInput.value)
+    
+    // Append to form and submit
+    this.formTarget.appendChild(odometerInput)
+    this.formTarget.submit()
+  }
+}

--- a/app/jobs/deactivate_trucks_job.rb
+++ b/app/jobs/deactivate_trucks_job.rb
@@ -3,7 +3,7 @@ class DeactivateTrucksJob < ApplicationJob
 
   def perform
     Truck.where(active: true).find_each do |truck|
-      next unless should_deactivate?(truck) # Skip if not eligible
+      next unless truck.should_deactivate? # Skip if not eligible
 
       begin
         truck.update!(active: false) # Use update! to raise an error if it fails
@@ -12,21 +12,5 @@ class DeactivateTrucksJob < ApplicationJob
         Rails.logger.error("❌ Failed to deactivate Truck ##{truck.id}: #{e.message}")
       end
     end
-  end
-
-  private
-
-  def should_deactivate?(truck)
-    return false unless truck.available?
-
-    last_form = truck.forms
-                     .maintenance_forms
-                     .order(Arel.sql("(forms.content->>'last_inspection_date')::date DESC")).first
-
-    return true if last_form.nil?
-    return true if last_form.content["last_inspection_date"] < 6.months.ago # Trucks must be inspected every 6 months
-    return true if truck.mileage - last_form.content["mileage"].to_i >= 25_000
-
-    false
   end
 end

--- a/app/services/close_delivery.rb
+++ b/app/services/close_delivery.rb
@@ -1,4 +1,4 @@
-require 'ostruct'
+require "ostruct"
 class CloseDelivery < ApplicationService
   def initialize(delivery, params)
     @delivery = delivery

--- a/app/services/close_delivery.rb
+++ b/app/services/close_delivery.rb
@@ -1,0 +1,47 @@
+class CloseDelivery < ApplicationService
+  def initialize(delivery, params)
+    @delivery = delivery
+    @odometer_reading = params[:odometer_reading]
+  end
+
+  def call
+    return failure("Delivery still has open shipments. It cannot be closed at this time.") unless @delivery.can_be_closed?
+    return failure("Odometer reading is incorrect. Please revise.") unless valid_odometer_reading?
+
+    ActiveRecord::Base.transaction do
+      update_truck_mileage
+      deactivate_truck_if_needed
+      complete_delivery
+    end
+
+    success("Delivery complete!")
+  rescue => e
+    failure("An error occurred while closing the delivery: #{e.message}")
+  end
+
+  private
+
+  def valid_odometer_reading?
+    @odometer_reading > @delivery.truck.mileage
+  end
+
+  def update_truck_mileage
+    @delivery.truck.update!(mileage: @odometer_reading)
+  end
+
+  def deactivate_truck_if_needed
+    @delivery.truck.deactivate! if @delivery.truck.should_deactivate?
+  end
+
+  def complete_delivery
+    @delivery.update!(status: :completed)
+  end
+
+  def success(message)
+    OpenStruct.new(success?: true, message: message)
+  end
+
+  def failure(error)
+    OpenStruct.new(success?: false, error: error)
+  end
+end

--- a/app/services/close_delivery.rb
+++ b/app/services/close_delivery.rb
@@ -1,7 +1,8 @@
+require 'ostruct'
 class CloseDelivery < ApplicationService
   def initialize(delivery, params)
     @delivery = delivery
-    @odometer_reading = params[:odometer_reading]
+    @odometer_reading = params[:odometer_reading].to_i
   end
 
   def call

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -15,7 +15,42 @@
   <div class="page-header">
     <h1 class="page-title">Delivery Details - <%= @delivery.status.humanize %></h1>
     <% if @delivery.can_be_closed? %>
-    <%= link_to "Mark Complete", close_delivery_path(@delivery), class: 'button primary-button', method: :post, data: { confirm: 'All shipments are successfully closed?' } %>
+    <div data-controller="complete-delivery">
+      <%= form_with url: close_delivery_path(@delivery), method: :post, data: { complete_delivery_target: "form" } do |f| %>
+      <!-- Modal Component -->
+      <div class="modal-overlay" data-complete-delivery-target="modal">
+        <div class="truck-load-modal-content">
+          <h3>Delivery Complete Confirmation</h3>
+          <p>All shipments are successfully closed?</p>
+
+          <div class="truck-load-modal-buttons">
+            <button type="button" class="button primary-button" data-complete-delivery-target="confirmBtn" data-action="click->complete-delivery#showOdometerInput">
+              Yes
+            </button>
+
+            <button type="button" class="button secondary-button" data-complete-delivery-target="cancelBtn" data-action="click->complete-delivery#hideModal">
+              No
+            </button>
+          </div>
+
+          <div class="address-container" data-complete-delivery-target="odometerContainer">
+            <label for="odometer-reading">Odometer Reading for <%= @delivery.truck.display_name %>:</label>
+            <input type="text" id="odometer-reading" class="form-control" data-complete-delivery-target="odometerInput">
+            <button type="button" class="button primary-button" data-action="click->complete-delivery#submitWithOdometer">
+              Submit
+            </button>
+
+            <button type="button" class="button secondary-button" data-action="click->complete-delivery#hideModal">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <%= button_tag "Mark Complete", class: "button primary-button", data: { action: "click->complete-delivery#showModal" } %>
+      <% end %>
+    </div>
+
     <% end %>
     <% if !@delivery.forms.empty? %>
     <button class="action-link" data-action="click->show-pre-delivery#open">

--- a/spec/javascript/controllers/complete_delivery_controller.test.js
+++ b/spec/javascript/controllers/complete_delivery_controller.test.js
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Application } from "@hotwired/stimulus";
+import CompleteDeliveryController from "controllers/complete_delivery_controller";
+
+describe("CompleteDeliveryController", () => {
+  let application;
+  let container;
+
+  beforeEach(() => {
+    // Set up the DOM structure
+    document.body.innerHTML = `
+      <div data-controller="complete-delivery">
+        <div data-complete-delivery-target="modal" class="modal">
+          <div class="modal-content">
+            <form data-complete-delivery-target="form">
+              <div data-complete-delivery-target="odometerContainer">
+                <input type="text" data-complete-delivery-target="odometerInput">
+              </div>
+              <button type="button" data-complete-delivery-target="confirmBtn" data-action="complete-delivery#confirmDelivery">Confirm</button>
+              <button type="button" data-complete-delivery-target="cancelBtn" data-action="complete-delivery#hideModal">Cancel</button>
+              <button type="button" data-action="complete-delivery#showOdometerInput">Yes</button>
+              <button type="button" data-action="complete-delivery#submitWithOdometer">Submit Odometer</button>
+            </form>
+          </div>
+        </div>
+        <button data-action="complete-delivery#showModal">Open Modal</button>
+      </div>
+    `;
+
+    // Initialize Stimulus
+    application = Application.start();
+    application.register("complete-delivery", CompleteDeliveryController);
+
+    // Get the container
+    container = document.querySelector('[data-controller="complete-delivery"]');
+  });
+
+  afterEach(() => {
+    // Clean up
+    document.body.innerHTML = "";
+    application.stop();
+  });
+
+  describe("connect", () => {
+    it("initializes with modal and odometer container hidden", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // Check initial state
+      expect(controller.modalTarget.style.display).toBe("none");
+      expect(controller.odometerContainerTarget.style.display).toBe("none");
+    });
+  });
+
+  describe("showModal", () => {
+    it("displays the modal when button is clicked", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+      
+      // Mock preventDefault
+      const mockEvent = { preventDefault: vi.fn() };
+      
+      // Trigger the action
+      controller.showModal(mockEvent);
+      
+      // Check if preventDefault was called
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      
+      // Check if modal is displayed
+      expect(controller.modalTarget.style.display).toBe("flex");
+    });
+  });
+
+  describe("hideModal", () => {
+    it("hides the modal and resets the odometer input", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // Set initial state
+      controller.modalTarget.style.display = "flex";
+      controller.odometerContainerTarget.style.display = "block";
+      controller.odometerInputTarget.value = "12345";
+      
+      // Trigger the action
+      controller.hideModal();
+      
+      // Check if modal and odometer container are hidden
+      expect(controller.modalTarget.style.display).toBe("none");
+      expect(controller.odometerContainerTarget.style.display).toBe("none");
+      
+      // Check if odometer input was reset
+      expect(controller.odometerInputTarget.value).toBe("");
+    });
+  });
+
+  describe("showOdometerInput", () => {
+    it("shows the odometer input container when Yes button is clicked", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // Initial state
+      controller.odometerContainerTarget.style.display = "none";
+      
+      // Trigger the action
+      controller.showOdometerInput();
+      
+      // Check if odometer container is shown
+      expect(controller.odometerContainerTarget.style.display).toBe("block");
+    });
+  });
+
+  describe("submitWithOdometer", () => {
+    it("appends the odometer reading to the form and submits it", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // Mock console.log to test logging
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      // Mock form submission
+      const mockSubmit = vi.fn();
+      controller.formTarget.submit = mockSubmit;
+      controller.odometerInputTarget.value = "54321";
+      
+      // Initial form state - no odometer input should exist
+      expect(controller.formTarget.querySelector('input[name="odometer_reading"]')).toBe(null);
+      
+      // Trigger the action
+      controller.submitWithOdometer();
+      
+      // Check if console.log was called with correct message
+      expect(consoleSpy).toHaveBeenCalledWith("Submitting with odometer value:", "54321");
+      
+      // Check if new hidden input was added
+      const odometerInput = controller.formTarget.querySelector('input[name="odometer_reading"]');
+      expect(odometerInput).not.toBe(null);
+      expect(odometerInput.type).toBe("hidden");
+      expect(odometerInput.value).toBe("54321");
+      
+      // Check if form was submitted
+      expect(mockSubmit).toHaveBeenCalled();
+      
+      // Clean up spy
+      consoleSpy.mockRestore();
+    });
+
+    it("handles empty odometer input", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // Mock form submission
+      const mockSubmit = vi.fn();
+      controller.formTarget.submit = mockSubmit;
+      controller.odometerInputTarget.value = "";
+      
+      // Trigger the action
+      controller.submitWithOdometer();
+      
+      // Check if hidden input was still created with empty value
+      const odometerInput = controller.formTarget.querySelector('input[name="odometer_reading"]');
+      expect(odometerInput).not.toBe(null);
+      expect(odometerInput.value).toBe("");
+      
+      // Check if form was submitted
+      expect(mockSubmit).toHaveBeenCalled();
+    });
+  });
+  
+  describe("integration", () => {
+    it("properly handles the complete workflow", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // Mock form submission
+      const mockSubmit = vi.fn();
+      controller.formTarget.submit = mockSubmit;
+      
+      // 1. Initially everything is hidden
+      expect(controller.modalTarget.style.display).toBe("none");
+      expect(controller.odometerContainerTarget.style.display).toBe("none");
+      
+      // 2. Open the modal
+      const openButton = document.querySelector('[data-action="complete-delivery#showModal"]');
+      openButton.dispatchEvent(new Event("click", { bubbles: true }));
+      expect(controller.modalTarget.style.display).toBe("flex");
+      
+      // 3. Show odometer input
+      const yesButton = document.querySelector('[data-action="complete-delivery#showOdometerInput"]');
+      yesButton.dispatchEvent(new Event("click", { bubbles: true }));
+      expect(controller.odometerContainerTarget.style.display).toBe("block");
+      
+      // 4. Enter odometer reading and submit
+      controller.odometerInputTarget.value = "98765";
+      const submitButton = document.querySelector('[data-action="complete-delivery#submitWithOdometer"]');
+      submitButton.dispatchEvent(new Event("click", { bubbles: true }));
+      
+      // Check if form was submitted with correct odometer reading
+      const odometerInput = controller.formTarget.querySelector('input[name="odometer_reading"]');
+      expect(odometerInput.value).toBe("98765");
+      expect(mockSubmit).toHaveBeenCalled();
+    });
+
+    it("properly handles hiding modal after showing odometer input", () => {
+      const controller = application.getControllerForElementAndIdentifier(container, "complete-delivery");
+
+      // 1. Open modal and show odometer input
+      controller.modalTarget.style.display = "flex";
+      controller.showOdometerInput();
+      controller.odometerInputTarget.value = "12345";
+      
+      // Verify initial state
+      expect(controller.modalTarget.style.display).toBe("flex");
+      expect(controller.odometerContainerTarget.style.display).toBe("block");
+      expect(controller.odometerInputTarget.value).toBe("12345");
+      
+      // 2. Hide the modal
+      controller.hideModal();
+      
+      // 3. Verify everything is reset
+      expect(controller.modalTarget.style.display).toBe("none");
+      expect(controller.odometerContainerTarget.style.display).toBe("none");
+      expect(controller.odometerInputTarget.value).toBe("");
+    });
+  });
+});

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -223,7 +223,6 @@ RSpec.describe Truck, type: :model do
   end
 
   describe "#should_deactivate?" do
-
     context "when the truck has an active delivery" do
       let!(:delivery) { create(:delivery, truck: valid_truck) }
 
@@ -234,7 +233,7 @@ RSpec.describe Truck, type: :model do
 
     context "when the truck has no maintenance forms" do
       let!(:truck_no_inspection) { create(:truck, active: true, mileage: 140_000) }
-      
+
       it "returns true" do
         expect(truck_no_inspection.should_deactivate?).to eq(true)
       end
@@ -253,7 +252,7 @@ RSpec.describe Truck, type: :model do
         expect(truck_old_inspection.should_deactivate?).to eq(true)
       end
     end
-    
+
     context "when the truck exceeds the mileage threshold" do
       let!(:truck_high_mileage) do
         create(:truck, active: true, mileage: 130_000).tap do |truck|

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -221,4 +221,81 @@ RSpec.describe Truck, type: :model do
       expect(valid_truck.latest_delivery).to eq(delivery)
     end
   end
+
+  describe "#should_deactivate?" do
+
+    context "when the truck has an active delivery" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+
+      it "returns false" do
+        expect(valid_truck.should_deactivate?).to eq(false)
+      end
+    end
+
+    context "when the truck has no maintenance forms" do
+      let!(:truck_no_inspection) { create(:truck, active: true, mileage: 140_000) }
+      
+      it "returns true" do
+        expect(truck_no_inspection.should_deactivate?).to eq(true)
+      end
+    end
+
+    context "when a truck has an old inspection" do
+      let!(:truck_old_inspection) do
+        create(:truck, active: true, mileage: 150_000).tap do |truck|
+          create(:form, :maintenance,
+                formable: truck,
+                custom_content: { "last_inspection_date" => 7.months.ago, "mileage" => 125_000 })
+        end
+      end
+
+      it "returns true" do
+        expect(truck_old_inspection.should_deactivate?).to eq(true)
+      end
+    end
+    
+    context "when the truck exceeds the mileage threshold" do
+      let!(:truck_high_mileage) do
+        create(:truck, active: true, mileage: 130_000).tap do |truck|
+          create(:form, :maintenance,
+                formable: truck,
+                custom_content: { "last_inspection_date" => 3.months.ago, "mileage" => 100_000 })
+        end
+      end
+
+      it "returns true" do
+        expect(truck_high_mileage.should_deactivate?).to eq(true)
+      end
+    end
+
+    context "when no conditions are met" do
+      let!(:passing_truck) do
+        create(:truck, active: true, mileage: 130_000).tap do |truck|
+          create(:form, :maintenance,
+                formable: truck,
+                custom_content: { "last_inspection_date" => 3.months.ago, "mileage" => 120_000 })
+        end
+      end
+      it "returns false" do
+        expect(passing_truck.should_deactivate?).to eq(false)
+      end
+    end
+  end
+
+  describe "#deactivate!" do
+    context "when the truck is active" do
+      it "deactivates the truck" do
+        valid_truck.deactivate!
+        expect(valid_truck.active).to eq(false)
+      end
+    end
+    context "when the truck is not active" do
+      let(:invalid_truck) { create(:truck, active: false) }
+
+      it "does not update the truck" do
+        expect { invalid_truck.deactivate! }
+          .not_to change { invalid_truck.reload.active }.from(false)
+      end
+    end
+  end
 end

--- a/spec/services/close_delivery_spec.rb
+++ b/spec/services/close_delivery_spec.rb
@@ -1,0 +1,241 @@
+require 'rails_helper'
+
+RSpec.describe CloseDelivery, type: :service do
+  let(:truck) { create(:truck, mileage: 10000) }
+  let(:delivery) { create(:delivery, truck: truck) }
+  let(:odometer_reading) { 10500 }
+  let(:params) { { odometer_reading: odometer_reading } }
+  
+  subject(:service) { described_class.new(delivery, params) }
+  subject(:result) { service.call }
+
+  describe '#call' do
+    context 'when delivery can be successfully closed' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+        allow(truck).to receive(:should_deactivate?).and_return(false)
+      end
+
+      it 'returns a successful result' do
+        expect(result.success?).to be true
+        expect(result.message).to eq("Delivery complete!")
+      end
+
+      it 'updates the truck mileage' do
+        expect { result }.to change { truck.reload.mileage }.from(10000).to(10500)
+      end
+
+      it 'completes the delivery' do
+        expect { result }.to change { delivery.reload.status }.to('completed')
+      end
+
+      it 'does not deactivate the truck when should_deactivate? returns false' do
+        expect(truck).not_to receive(:deactivate!)
+        result
+      end
+
+      context 'when truck should be deactivated' do
+        before do
+          allow(truck).to receive(:should_deactivate?).and_return(true)
+        end
+
+        it 'deactivates the truck' do
+          expect(truck).to receive(:deactivate!)
+          result
+        end
+      end
+    end
+
+    context 'when delivery cannot be closed' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(false)
+      end
+
+      it 'returns a failure result' do
+        expect(result.success?).to be false
+        expect(result.error).to eq("Delivery still has open shipments. It cannot be closed at this time.")
+      end
+
+      it 'does not update truck mileage' do
+        expect { result }.not_to change { truck.reload.mileage }
+      end
+
+      it 'does not complete the delivery' do
+        expect { result }.not_to change { delivery.reload.status }
+      end
+    end
+
+    context 'when odometer reading is invalid' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+      end
+
+      context 'when odometer reading is less than current truck mileage' do
+        let(:odometer_reading) { 9500 }
+
+        it 'returns a failure result' do
+          expect(result.success?).to be false
+          expect(result.error).to eq("Odometer reading is incorrect. Please revise.")
+        end
+
+        it 'does not update truck mileage' do
+          expect { result }.not_to change { truck.reload.mileage }
+        end
+
+        it 'does not complete the delivery' do
+          expect { result }.not_to change { delivery.reload.status }
+        end
+      end
+
+      context 'when odometer reading equals current truck mileage' do
+        let(:odometer_reading) { 10000 }
+
+        it 'returns a failure result' do
+          expect(result.success?).to be false
+          expect(result.error).to eq("Odometer reading is incorrect. Please revise.")
+        end
+      end
+    end
+
+    context 'when an exception occurs during transaction' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+        allow(truck).to receive(:update!).and_raise(StandardError.new("Database error"))
+      end
+
+      it 'returns a failure result with error message' do
+        expect(result.success?).to be false
+        expect(result.error).to eq("An error occurred while closing the delivery: Database error")
+      end
+
+      it 'does not complete the delivery due to transaction rollback' do
+        expect { result }.not_to change { delivery.reload.status }
+      end
+    end
+
+    context 'when truck update fails' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+        allow(truck).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(truck))
+      end
+
+      it 'handles the exception and returns failure' do
+        expect(result.success?).to be false
+        expect(result.error).to start_with("An error occurred while closing the delivery:")
+      end
+    end
+
+    context 'when delivery status update fails' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+        allow(delivery).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(delivery))
+      end
+
+      it 'handles the exception and returns failure' do
+        expect(result.success?).to be false
+        expect(result.error).to start_with("An error occurred while closing the delivery:")
+      end
+
+      it 'rolls back truck mileage update due to transaction' do
+        original_mileage = truck.mileage
+        result
+        expect(truck.reload.mileage).to eq(original_mileage)
+      end
+    end
+
+    context 'when truck deactivation fails' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+        allow(truck).to receive(:should_deactivate?).and_return(true)
+        allow(truck).to receive(:deactivate!).and_raise(StandardError.new("Deactivation failed"))
+      end
+
+      it 'handles the exception and returns failure' do
+        expect(result.success?).to be false
+        expect(result.error).to eq("An error occurred while closing the delivery: Deactivation failed")
+      end
+
+      it 'rolls back all changes due to transaction' do
+        original_mileage = truck.mileage
+        original_status = delivery.status
+        result
+        expect(truck.reload.mileage).to eq(original_mileage)
+        expect(delivery.reload.status).to eq(original_status)
+      end
+    end
+  end
+
+  describe '#initialize' do
+    it 'sets delivery and odometer_reading instance variables' do
+      service = described_class.new(delivery, params)
+      expect(service.instance_variable_get(:@delivery)).to eq(delivery)
+      expect(service.instance_variable_get(:@odometer_reading)).to eq(odometer_reading)
+    end
+  end
+
+  describe 'private methods' do
+    describe '#valid_odometer_reading?' do
+      it 'returns true when odometer reading is greater than truck mileage' do
+        expect(service.send(:valid_odometer_reading?)).to be true
+      end
+
+      it 'returns false when odometer reading is less than truck mileage' do
+        service.instance_variable_set(:@odometer_reading, 9500)
+        expect(service.send(:valid_odometer_reading?)).to be false
+      end
+
+      it 'returns false when odometer reading equals truck mileage' do
+        service.instance_variable_set(:@odometer_reading, 10000)
+        expect(service.send(:valid_odometer_reading?)).to be false
+      end
+    end
+
+    describe '#success' do
+      it 'returns an OpenStruct with success? true and message' do
+        result = service.send(:success, "Test message")
+        expect(result.success?).to be true
+        expect(result.message).to eq("Test message")
+      end
+    end
+
+    describe '#failure' do
+      it 'returns an OpenStruct with success? false and error' do
+        result = service.send(:failure, "Test error")
+        expect(result.success?).to be false
+        expect(result.error).to eq("Test error")
+      end
+    end
+  end
+
+  # Integration-style tests to ensure the full flow works
+  describe 'integration scenarios' do
+    context 'complete successful delivery closure' do
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+        allow(truck).to receive(:should_deactivate?).and_return(true)
+      end
+
+      it 'performs all operations in correct order' do
+        expect(truck).to receive(:update!).with(mileage: odometer_reading).ordered
+        expect(truck).to receive(:deactivate!).ordered
+        expect(delivery).to receive(:update!).with(status: :completed).ordered
+        
+        result
+      end
+    end
+
+    context 'with edge case odometer readings' do
+      let(:truck) { create(:truck, mileage: 0) }
+      let(:odometer_reading) { 1 }
+
+      before do
+        allow(delivery).to receive(:can_be_closed?).and_return(true)
+      end
+
+      it 'handles very small positive differences' do
+        expect(result.success?).to be true
+        expect(truck.reload.mileage).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR adds a stimulus controller and backend service to update truck odometers at the end of a delivery.

## Approach Taken
I opted to augment the Truck model with some helper methods, create a dedicated stimulus controller to handle the front end delivery closure, then created a dedicated service object since the close action was getting quite bloated.

## What Could Go Wrong?
Carries all risks associated with a usual backend change.

## Remediation Strategy 
Rollback if needed.
