### PR TITLE
XMDEV-317: Updates driver creation to generate temp password and send email

### DIFF
--- a/app/controllers/driver_managements_controller.rb
+++ b/app/controllers/driver_managements_controller.rb
@@ -9,10 +9,17 @@ class DriverManagementsController < ApplicationController
 
     def create
       authorize :driver_management, :create?
+      temp_password = Devise.friendly_token.first(12)
+
       @driver = User.new(driver_params)
+      @driver.password = temp_password
+      @driver.password_confirmation = temp_password
+
       @driver.role = "driver"
       @driver.company = current_user.company
+
       if @driver.save
+        DriverMailer.send_temp_password(@driver, temp_password).deliver_later
         redirect_to admin_index_path, notice: "Driver account created successfully."
       else
         render :new, status: :unprocessable_entity, alert: "Unable to create driver account."
@@ -39,6 +46,6 @@ class DriverManagementsController < ApplicationController
     end
 
     def driver_params
-      params.require(:user).permit(:first_name, :last_name, :home_address, :drivers_license, :email, :password, :password_confirmation)
+      params.require(:user).permit(:first_name, :last_name, :home_address, :drivers_license, :email)
     end
 end

--- a/app/mailers/driver_mailer.rb
+++ b/app/mailers/driver_mailer.rb
@@ -1,0 +1,7 @@
+class DriverMailer < ApplicationMailer
+  def send_temp_password(user, temp_password)
+    @user = user
+    @temp_password = temp_password
+    mail(to: @user.email, subject: "Your Account Has Been Created")
+  end
+end

--- a/app/views/driver_mailer/send_temp_password.html.erb
+++ b/app/views/driver_mailer/send_temp_password.html.erb
@@ -1,0 +1,75 @@
+<style type="text/css">
+  body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    line-height: 1.6;
+    font-size: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #09e80d;
+    margin-bottom: 10px;
+  }
+
+  .details-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+
+  .detail-value {
+    color: #336699;
+  }
+
+  .password-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin: 20px 0;
+    text-align: center;
+  }
+
+  .temp-password {
+    font-size: 18px;
+    font-weight: bold;
+    color: #ffffff;
+    letter-spacing: 2px;
+    padding: 10px;
+    background-color: #09e80d;
+    border: 2px solid #09e80d;
+    border-radius: 4px;
+    display: inline-block;
+    margin: 10px 0;
+  }
+
+  .warning-text {
+    color: #2c3e50;
+    font-weight: bold;
+    margin-top: 15px;
+  }
+</style>
+
+<h1>Welcome to Our Platform!</h1>
+<p>Hello <%= @user.display_name %>,</p>
+<p>Your account has been created successfully. We're excited to have you join our platform!</p>
+
+<h2>Login Information</h2>
+<div class="details-container">
+  <p><strong>Username/Email:</strong> <span class="detail-value"><%= @user.email %></span></p>
+  <p><strong>Account Status:</strong> <span class="detail-value">Active</span></p>
+</div>
+
+<div class="password-container">
+  <p>Use the following temporary password to log in:</p>
+  <div class="temp-password"><%= @temp_password %></div>
+  <p class="warning-text">Please change your password after logging in for security purposes.</p>
+</div>
+
+<p>If you have any questions or need assistance, please don't hesitate to contact our support team.</p>
+<p>Welcome aboard!</p>

--- a/app/views/driver_managements/new.html.erb
+++ b/app/views/driver_managements/new.html.erb
@@ -36,16 +36,6 @@
     <%= f.email_field :email, class: 'form-input', required: true %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :password, nil, class: 'form-label' %>
-    <%= f.password_field :password, class: 'form-input', required: true %>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :password_confirmation, "Password Confirmation", class: 'form-label' %>
-    <%= f.password_field :password_confirmation, class: 'form-input', required: true %>
-  </div>
-
   <div class="details-actions">
     <%= f.submit "Create Driver", class: 'primary-button' %>
   </div>

--- a/spec/mailers/driver_mailer_spec.rb
+++ b/spec/mailers/driver_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe DriverMailer, type: :mailer do
+  describe ".send_temp_password" do
+    let(:user) { create(:user, email: "test@example.com", first_name: "Bobby", last_name: "B") }
+    let(:temp_password) { "Abcd1234!@#" }
+    let(:mail) { described_class.send_temp_password(user, temp_password) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your Account Has Been Created")
+      expect(mail.to).to eq([ "test@example.com" ])
+      expect(mail.from).to eq([ Rails.application.credentials.dig(:mailer, :default_from) || "from@example.com" ])
+    end
+
+    it "renders the body with the user's name" do
+      expect(mail.body.encoded).to include("Hello Bobby B")
+    end
+
+    it "includes the temporary password in the email body" do
+      expect(mail.body.encoded).to include(temp_password)
+    end
+
+    it "encourages the user to change their password" do
+      expect(mail.body.encoded).to include("Please change your password after logging in")
+    end
+  end
+end

--- a/spec/mailers/previews/driver_mailer_preview.rb
+++ b/spec/mailers/previews/driver_mailer_preview.rb
@@ -1,0 +1,12 @@
+# Preview all emails at http://localhost:3000/rails/mailers/driver_mailer_mailer
+class DriverMailerPreview < ActionMailer::Preview
+  def send_temp_password
+    user = User.new(
+      email: "demo.driver@example.com",
+      first_name: "Demo",
+      last_name: "Driver"
+    )
+    temp_password = "Temp1234@Preview"
+    DriverMailer.send_temp_password(user, temp_password)
+  end
+end


### PR DESCRIPTION
## Description
The previous workflow was for the admin to choose the password of the newly created driver. This was insecure, so this PR updates the app so that the temp password is generated automatically and then sent to the user.

## Approach Taken
Augment the create action, and trigger an email to be sent.

## What Could Go Wrong?
Since this augments the create action, if there were any issues, it would inhibit admins in creating drivers for their company. This change has been tested thoroughly, so this is not a real concern.

## Remediation Strategy 
Rollback if needed.
