### PR TITLE
XMDEV-358: Change alert button verbiage on quick close to work with Ok and Cancel options

### DIFF
--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -91,7 +91,7 @@
           <%= link_to 'Quick Close', close_shipment_path(shipment), 
             class: 'action-link', 
             method: :post, 
-            data: { confirm: 'Was this shipment successfully delivered?' } %> |
+            data: { confirm: "Mark this shipment as Delivered?" } %> |
           <% end %>
           <%= link_to 'Show', shipment, class: 'action-link' %> |
           <%= link_to 'Edit', edit_shipment_path(shipment), class: 'action-link' %>

--- a/docs/user_journeys/driver_setting_a_delivery_to_closed.md
+++ b/docs/user_journeys/driver_setting_a_delivery_to_closed.md
@@ -73,7 +73,6 @@ As Peter completes the physical delivery of packages to their destination, he mu
 ## Opportunities
 
 - **XMDEV-357**: Hide Quick Close button if not configured by the company
-- **XMDEV-358**: Change alert button label from `OK` to `Yes` for better clarity
 - **XMDEV-359**: Hide receiver address on the Delivery Show page if delivery is in progress
 - **XMDEV-361**: Fix bug preventing delivery from closing after manual shipment closure
 


### PR DESCRIPTION
## Description
While articulating our user journeys, we found that the data confirm string on quick close was confusing given the alert buttons options of Ok, and Cancel.

## Approach Taken
Updated the data confirm string on quick close to make the options.

## What Could Go Wrong?
Nothing major. Purely a cosmetic change on the frontend.

## Remediation Strategy 
NA
