### PR TITLE
XMDEV-357: Hides quick close button if company does not have the status configured

### DIFF
--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -12,6 +12,11 @@ class DeliveriesController < ApplicationController
     authorize @delivery
     @open_shipments = @delivery.open_shipments.distinct
     @delivered_shipments = @delivery.delivered_shipments.distinct
+
+    @shipment_status = ShipmentActionPreference
+                       .includes(:shipment_status)
+                       .find_by(action: "successfully_delivered", company_id: current_company.id)
+                       &.shipment_status
   end
 
   def close

--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -87,11 +87,11 @@
         <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
         <td>
-          <% if @delivery.in_progress? %>
+          <% if @delivery.in_progress? && @shipment_status%>
           <%= link_to 'Quick Close', close_shipment_path(shipment), 
             class: 'action-link', 
             method: :post, 
-            data: { confirm: "Mark this shipment as Delivered?" } %> |
+            data: { confirm: "Mark this shipment as #{@shipment_status.name}?" } %> |
           <% end %>
           <%= link_to 'Show', shipment, class: 'action-link' %> |
           <%= link_to 'Edit', edit_shipment_path(shipment), class: 'action-link' %>

--- a/docs/user_journeys/driver_setting_a_delivery_to_closed.md
+++ b/docs/user_journeys/driver_setting_a_delivery_to_closed.md
@@ -72,7 +72,6 @@ As Peter completes the physical delivery of packages to their destination, he mu
 
 ## Opportunities
 
-- **XMDEV-357**: Hide Quick Close button if not configured by the company
 - **XMDEV-359**: Hide receiver address on the Delivery Show page if delivery is in progress
 - **XMDEV-361**: Fix bug preventing delivery from closing after manual shipment closure
 


### PR DESCRIPTION
## Description
While articulating our user journeys, it was found that the showing of the quick close button, despite a company not having the status configured, was confusing.

## Approach Taken
Conditionally renders the quick close button if the company has the status configured.

## What Could Go Wrong?
Primarily a frontend cosmetic change. Backend query has been checked to be robust in the event of a nil value.

## Remediation Strategy 
NA
