### PR TITLE
XMDEV-340: Updates company form button to say Create or Update

### DIFF
--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -1,26 +1,26 @@
 <%= form_with(model: company, local: true, class: 'styled-form') do |f| %>
-  <% if company.errors.any? %>
-    <div class="error-messages">
-      <h2><%= pluralize(company.errors.count, "error") %> prohibited this company from being saved:</h2>
-      <ul>
-        <% company.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<% if company.errors.any? %>
+<div class="error-messages">
+  <h2><%= pluralize(company.errors.count, "error") %> prohibited this company from being saved:</h2>
+  <ul>
+    <% company.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>
 
-  <div class="form-group">
-    <%= f.label :name, "Company Name", class: 'form-label' %>
-    <%= f.text_field :name, class: 'form-input', required: true %>
-  </div>
+<div class="form-group">
+  <%= f.label :name, "Company Name", class: 'form-label' %>
+  <%= f.text_field :name, class: 'form-input', required: true %>
+</div>
 
-  <div class="form-group">
-    <%= f.label :address, "Company Address", class: 'form-label' %>
-    <%= f.text_field :address, class: 'form-input', required: true %>
-  </div>
+<div class="form-group">
+  <%= f.label :address, "Company Address", class: 'form-label' %>
+  <%= f.text_field :address, class: 'form-input', required: true %>
+</div>
 
-  <div class="form-actions">
-    <%= f.submit "Save Company", class: "button primary-button" %>
-  </div>
+<div class="form-actions">
+  <%= f.submit button_text, class: "button primary-button" %>
+</div>
 <% end %>

--- a/app/views/companies/edit.html.erb
+++ b/app/views/companies/edit.html.erb
@@ -4,5 +4,5 @@
 </div>
 
 <div class="form-container">
-  <%= render 'form', company: @company %>
+  <%= render 'form', company: @company, button_text: "Update Company" %>
 </div>

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -4,5 +4,5 @@
 </div>
 
 <div class="form-container">
-  <%= render 'form', company: @company %>
+  <%= render 'form', company: @company, button_text: "Create Company" %>
 </div>

--- a/docs/user_journeys/trucking_professional_signup.md
+++ b/docs/user_journeys/trucking_professional_signup.md
@@ -39,22 +39,20 @@ This user likely discovered Truckin' Along via word of mouth or marketing effort
 
 4. **Initial Redirect**
 
-   - Upon successful sign-up, the user is redirected back to the homepage.
+   - Upon successful sign-up, the user is redirected back to _Create Company_ page.
    - A banner appears at the top:  
      `Welcome! You have signed up successfully.`
-   - At this point, the homepage still displays the original sign-up buttons.
 
 5. **Company Creation Trigger**
 
-   - When the user clicks on any navigation link after signing up, they're prompted to create their company.
    - A new form appears requiring:
      - Company Name
      - Company Address
-   - The user completes the form and clicks `Save Company`.
+   - The user completes the form and clicks `Create Company`.
 
 6. **Final Step**
 
-   - After creating the company, the user is directed to the page they originally clicked on.
+   - After creating the company, the user is directed to the _My Dashboard_ page.
    - They now have full access to the platform’s features as a trucking professional.
 
 ---
@@ -63,24 +61,19 @@ This user likely discovered Truckin' Along via word of mouth or marketing effort
 
 - 🟢 Pleased with the lightweight sign-up process
 - 🟢 Appreciates the minimal cognitive load
-- 🟡 Confused by being redirected to the same homepage post-signup
-- 🟡 Unclear that they must create a company before using the platform
-- 🟡 Confused by the label `Save Company`, which implies support for multiple companies when that is not currently the case
+- 🟢 Pleased with the sequenced flow of creating a user account, then a company
 
 ---
 
 ## Pain Points
 
-- Lack of clear indication that the user is signed in after account creation
-- Disjointed flow between user sign-up and company creation
+- None currently reported in this workflow
 
 ---
 
 ## Opportunities
 
-- Update homepage content post-login to reflect the user’s authenticated state and role more clearly _(XMDEV-316)_
-- Prompt trucking professionals to create their company **immediately** after completing personal sign-up _(XMDEV-319)_
-- Consider renaming the `Save Company` button to something more accurate, like `Create Company` _(XMDEV-340)_
+- None currently reported in this workflow
 
 ---
 

--- a/docs/user_journeys/trucking_professional_signup.md
+++ b/docs/user_journeys/trucking_professional_signup.md
@@ -39,7 +39,7 @@ This user likely discovered Truckin' Along via word of mouth or marketing effort
 
 4. **Initial Redirect**
 
-   - Upon successful sign-up, the user is redirected back to _Create Company_ page.
+   - Upon successful sign-up, the user is redirected to _Create Company_ page.
    - A banner appears at the top:  
      `Welcome! You have signed up successfully.`
 


### PR DESCRIPTION
## Description
While articulating our user journeys, we found that the copy on the button for company create and update actions was confusing. The previous copy implied that a user could create multiple companies which wasn't the case.

## Approach Taken
On the base view for the two affected pages, adds a local variable called `button_text` to dictate the button text of the associated form.

## What Could Go Wrong?
Nothing major. This is solely a frontend copy change on a button.

## Remediation Strategy 
NA
