### PR TITLE
Odometer hint and formatting

### DIFF
--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -34,8 +34,8 @@
           </div>
 
           <div class="address-container" data-complete-delivery-target="odometerContainer">
-            <label for="odometer-reading">Odometer Reading for <%= @delivery.truck.display_name %>:</label>
-            <input type="text" id="odometer-reading" class="form-control" data-complete-delivery-target="odometerInput">
+            <label for="odometer-reading">Odometer Reading (e.g., 148723):</label>
+            <input type="number" min="0" step="1" id="odometer-reading" class="form-control" data-complete-delivery-target="odometerInput">
             <button type="button" class="button primary-button" data-action="click->complete-delivery#submitWithOdometer">
               Submit
             </button>

--- a/app/views/forms/_maintenance_form.html.erb
+++ b/app/views/forms/_maintenance_form.html.erb
@@ -14,8 +14,8 @@
         <label for="form-title">Date of completion:</label>
         <input type="text" id="form-title" name="last_inspection_date" class="form-input" required value=<%= Date.today %>>
 
-        <label for="form-title">Mileage:</label>
-        <input type="text" id="form-title" name="mileage" class="form-input" required>
+        <label for="form-title">Odometer Reading (e.g., 148723):</label>
+        <input type="number" min="0" step="1" id="form-title" name="mileage" class="form-input" required>
       </div>
 
       <div class="checklist-group">

--- a/docs/user_journeys/trucking_company_marking_delivery_complete.md
+++ b/docs/user_journeys/trucking_company_marking_delivery_complete.md
@@ -70,7 +70,6 @@ After completing all associated deliveries, the driver (or admin) needs to forma
 
 ## Opportunities
 
-- **XMDEV-364**: Add input formatting and hint text to odometer field to reduce validation issues (e.g., `e.g., 148723`)
 - **XMDEV-363**: Improve error messaging to explain what was incorrect (e.g., “Odometer reading must be higher than starting value”)
 - **XMDEV-362**: If the delivery is not eligible for completion (e.g., shipments still open), disable or hide the `Mark Complete` button until criteria are met
 


### PR DESCRIPTION
## Description
The odometer reading fields were text fields, which gave users the option to enter in any text. This was incorrect, so we wanted to enforce that solely numbers would be entered in these fields.

## Approach Taken
Checked the input type and added min and step attributes to ensure a positive integer value.

## What Could Go Wrong?
This adds some additional front end validation to the odometer reading/mileage field. Worse case scenario is users bypass it, however we have backend validation to catch it anywhere. Nothing major could go wrong with this change.

## Remediation Strategy 
NA
