### PR TITLE
XMDEV-363: Updates error messaging to explain issue with odometer reading

### DIFF
--- a/app/services/close_delivery.rb
+++ b/app/services/close_delivery.rb
@@ -7,7 +7,7 @@ class CloseDelivery < ApplicationService
 
   def call
     return failure("Delivery still has open shipments. It cannot be closed at this time.") unless @delivery.can_be_closed?
-    return failure("Odometer reading is incorrect. Please revise.") unless valid_odometer_reading?
+    return failure("Odometer reading must be higher than previous value. Please revise.") unless valid_odometer_reading?
 
     ActiveRecord::Base.transaction do
       update_truck_mileage

--- a/docs/user_journeys/trucking_company_marking_delivery_complete.md
+++ b/docs/user_journeys/trucking_company_marking_delivery_complete.md
@@ -59,6 +59,7 @@ After completing all associated deliveries, the driver (or admin) needs to forma
 ## Emotions
 
 - 🟢 Pleased with how simple and straightforward it is to mark a delivery complete
+- 🟢 Pleased with information provided when there is an error with the odometer value
 
 ---
 
@@ -70,11 +71,10 @@ After completing all associated deliveries, the driver (or admin) needs to forma
 
 ## Opportunities
 
-- **XMDEV-363**: Improve error messaging to explain what was incorrect (e.g., “Odometer reading must be higher than starting value”)
 - **XMDEV-362**: If the delivery is not eligible for completion (e.g., shipments still open), disable or hide the `Mark Complete` button until criteria are met
 
 ---
 
 ## Outcome
 
-At the end of the journey, the user successfully marked the delivery as complete, making the truck available for reassignment and triggering backend actions like maintenance checks. While generally efficient, the experience could be improved by refining the odometer input flow and enhancing error clarity.
+At the end of the journey, the user successfully marked the delivery as complete, making the truck available for reassignment and triggering backend actions like maintenance checks.

--- a/spec/requests/deliveries_spec.rb
+++ b/spec/requests/deliveries_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "/deliveries", type: :request do
 
           it "shows an alert saying odometer reading is incorrect" do
             post close_delivery_url(delivery), params: { odometer_reading: invalid_odometer_reading }
-            expect(flash[:alert]).to eq("Odometer reading is incorrect. Please revise.")
+            expect(flash[:alert]).to eq("Odometer reading must be higher than previous value. Please revise.")
           end
 
           it "does not close the delivery" do
@@ -184,7 +184,7 @@ RSpec.describe "/deliveries", type: :request do
 
           it "shows an alert saying odometer reading is incorrect" do
             post close_delivery_url(delivery)
-            expect(flash[:alert]).to eq("Odometer reading is incorrect. Please revise.")
+            expect(flash[:alert]).to eq("Odometer reading must be higher than previous value. Please revise.")
           end
 
           it "does not close the delivery" do

--- a/spec/services/close_delivery_spec.rb
+++ b/spec/services/close_delivery_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CloseDelivery, type: :service do
 
         it 'returns a failure result' do
           expect(result.success?).to be false
-          expect(result.error).to eq("Odometer reading is incorrect. Please revise.")
+          expect(result.error).to eq("Odometer reading must be higher than previous value. Please revise.")
         end
 
         it 'does not update truck mileage' do
@@ -92,7 +92,7 @@ RSpec.describe CloseDelivery, type: :service do
 
         it 'returns a failure result' do
           expect(result.success?).to be false
-          expect(result.error).to eq("Odometer reading is incorrect. Please revise.")
+          expect(result.error).to eq("Odometer reading must be higher than previous value. Please revise.")
         end
       end
     end


### PR DESCRIPTION
## Description
While working through out user journeys, some users found the error message confusing when there was an issue with updating the odometer reading. This change aims to clarify the issue.

## Approach Taken
Updates the error message to be more informative.

## What Could Go Wrong?
This is a refactor for an error message. No real change to any currently working functions except for a change in verbiage for an error update.

## Remediation Strategy 
NA
