### PR TITLE
XMDEV-344: Adds phone_number attribute for companies

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -47,7 +47,7 @@ class CompaniesController < ApplicationController
   end
 
   def company_params
-    params.require(:company).permit(:name, :address)
+    params.require(:company).permit(:name, :address, :phone_number)
   end
 
   def setup_company_defaults(company)

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -11,9 +11,9 @@ class Company < ApplicationRecord
   validates :address, presence: true
 
   validates :phone_number,
-            presence: true,
-            format: {
-              with: /\A\+?[\d\s\-()]{10,20}\z/,
-              message: "must be a valid phone number (can include +, -, space, parentheses)"
-            }
+          allow_blank: true,
+          format: {
+            with: /\A\+?[\d\s\-()]{10,20}\z/,
+            message: "must be a valid phone number (can include +, -, space, parentheses)"
+          }
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,4 +9,11 @@ class Company < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :address, presence: true
+
+  validates :phone_number,
+            presence: true,
+            format: {
+              with: /\A\+?[\d\s\-()]{10,20}\z/,
+              message: "must be a valid phone number (can include +, -, space, parentheses)"
+            }
 end

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -22,7 +22,7 @@
 
 <div class="form-group">
   <%= f.label :phone_number, "Company Phone Number", class: 'form-label' %>
-  <%= f.text_field :phone_number, class: 'form-input', required: true %>
+  <%= f.text_field :phone_number, class: 'form-input', required: false %>
 </div>
 
 <div class="form-actions">

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -20,6 +20,11 @@
   <%= f.text_field :address, class: 'form-input', required: true %>
 </div>
 
+<div class="form-group">
+  <%= f.label :phone_number, "Company Phone Number", class: 'form-label' %>
+  <%= f.text_field :phone_number, class: 'form-input', required: true %>
+</div>
+
 <div class="form-actions">
   <%= f.submit button_text, class: "button primary-button" %>
 </div>

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -58,7 +58,15 @@
   <tbody>
     <% @shipment.delivery_shipments.each do |del_ship| %>
     <tr>
-      <td><%= @shipment.company&.name || del_ship.delivery&.user.company.name %></td>
+      <td>
+        <% company = @shipment.company || del_ship.delivery&.user&.company %>
+        <%= company&.name %>
+        <% if company&.phone_number.present? %>
+        <span style="cursor: help;" title="Phone: <%= company.phone_number %>">
+          &#9432;
+        </span>
+        <% end %>
+      </td>
       <td><%= del_ship.sender_address %></td>
       <td><%= del_ship.receiver_address %></td>
       <td><%= del_ship.loaded_date&.strftime("%Y-%m-%d") %></td>

--- a/db/migrate/20250601211809_add_company_phone_number.rb
+++ b/db/migrate/20250601211809_add_company_phone_number.rb
@@ -1,0 +1,11 @@
+class AddCompanyPhoneNumber < ActiveRecord::Migration[8.0]
+  include MigrationHelpers::IdempotentMigration
+
+  def up
+    add_column_unless_exists :companies, :phone_number, :string
+  end
+
+  def down
+    remove_column_if_exists :companies, :phone_number
+  end
+end

--- a/db/migrate/20250601211809_add_company_phone_number.rb
+++ b/db/migrate/20250601211809_add_company_phone_number.rb
@@ -2,7 +2,7 @@ class AddCompanyPhoneNumber < ActiveRecord::Migration[8.0]
   include MigrationHelpers::IdempotentMigration
 
   def up
-    add_column_unless_exists :companies, :phone_number, :string
+    add_column_unless_exists :companies, :phone_number, :string, null: true
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_10_224138) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_01_211809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_10_224138) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "phone_number"
   end
 
   create_table "deliveries", force: :cascade do |t|

--- a/docs/erd.mermaid
+++ b/docs/erd.mermaid
@@ -27,6 +27,7 @@ erDiagram
         bigint id PK
         string name
         string address
+        string phone_number
         datetime created_at
         datetime updated_at
     }

--- a/docs/user_journeys/customer_monitoring_shipment.md
+++ b/docs/user_journeys/customer_monitoring_shipment.md
@@ -50,7 +50,7 @@ The customer wants to track the progress of their shipment to understand how far
 ## Emotions
 
 - 🟢 Feels well-informed by email notifications about shipment activity
-- 🟢 Appreciates being able to track the shipment and identify the carrier
+- 🟢 Appreciates being able to track the shipment and identify and contact the carrier
 - 🟡 Frustrated by difficulty identifying the correct shipment on the index page
 - 🟡 Confused by delivery events being displayed out of order
 
@@ -66,7 +66,6 @@ The customer wants to track the progress of their shipment to understand how far
 ## Opportunities
 
 - Maintain and improve shipment-claimed email notifications _(XMDEV-343)_
-- Enable customers to easily call the assigned trucking company from the interface for support _(XMDEV-344)_
 
 ---
 

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :company do
     name { "#{Faker::Company.name} #{SecureRandom.uuid}" }
     address { Faker::Address.full_address }
+    phone_number { "+1#{Faker::Number.number(digits: 10)}" }
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,15 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe Company, type: :model do
-  it { should have_many(:shipments).dependent(:nullify) }
+  subject { build(:company) }
 
+  # Associations
+  it { should have_many(:shipments).dependent(:nullify) }
   it { should have_many(:users).dependent(:destroy) }
   it { should have_many(:shipment_statuses).dependent(:destroy) }
   it { should have_many(:trucks).dependent(:destroy) }
   it { should have_many(:shipment_action_preferences).dependent(:destroy) }
   it { should have_many(:forms).dependent(:destroy) }
 
+  # Validations
   it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:address) }
   it { should validate_uniqueness_of(:name) }
+  it { should validate_presence_of(:address) }
+  it { should validate_presence_of(:phone_number) }
+
+  describe 'phone_number format' do
+    it 'is valid with correct format' do
+      valid_numbers = [
+        '+1234567890',
+        '123-456-7890',
+        '(123) 456-7890',
+        '+1 (123) 456-7890',
+        '123 456 7890',
+        '+44 7911 123456'
+      ]
+
+      valid_numbers.each do |number|
+        subject.phone_number = number
+        expect(subject).to be_valid, "expected #{number.inspect} to be valid"
+      end
+    end
+
+    it 'is invalid with incorrect format' do
+      invalid_numbers = [
+        'abc1234567',
+        '123-abc-7890',
+        '123456', # too short
+        '+1(123)456-7890ext',
+        '++1234567890',
+        '123_456_7890'
+      ]
+
+      invalid_numbers.each do |number|
+        subject.phone_number = number
+        expect(subject).not_to be_valid, "expected #{number.inspect} to be invalid"
+      end
+    end
+  end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Company, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_uniqueness_of(:name) }
   it { should validate_presence_of(:address) }
-  it { should validate_presence_of(:phone_number) }
 
   describe 'phone_number format' do
     it 'is valid with correct format' do
@@ -34,11 +33,16 @@ RSpec.describe Company, type: :model do
       end
     end
 
+    it 'is valid when blank' do
+      subject.phone_number = nil
+      expect(subject).to be_valid
+    end
+
     it 'is invalid with incorrect format' do
       invalid_numbers = [
         'abc1234567',
         '123-abc-7890',
-        '123456', # too short
+        '123456',
         '+1(123)456-7890ext',
         '++1234567890',
         '123_456_7890'

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -9,21 +9,24 @@ RSpec.describe "/companies", type: :request do
   let(:valid_attributes) {
     {
       name: "Test Company",
-      address: "123 Test Street"
+      address: "123 Test Street",
+      phone_number: "6479808236"
     }
   }
 
   let(:invalid_attributes) {
     {
       name: nil,
-      address: nil
+      address: nil,
+      phone_number: nil
     }
   }
 
   let(:new_attributes) {
     {
       name: "Updated Company",
-      address: "456 Updated Street"
+      address: "456 Updated Street",
+      phone_number: "+16479808236"
     }
   }
 
@@ -167,6 +170,7 @@ RSpec.describe "/companies", type: :request do
           company.reload
           expect(company.name).to eq("Updated Company")
           expect(company.address).to eq("456 Updated Street")
+          expect(company.phone_number).to eq("+16479808236")
         end
 
         it "redirects to the dashboard page" do


### PR DESCRIPTION
## Description
While articulating our user journeys, customers sometimes wanted to get in touch with the company that had their shipment in the past. Therefore, we opted to add a phone number attribute for all companies so they can optionally share a number with customers.

## Approach Taken
Adds a new attribute to the companies model. Updates associated views to show company number where needed.

## What Could Go Wrong?
Care has been taken to write an idempotent migration. This change yields a couple data updates to the frontend. Proper validation is in place. Current users, the next time they attempt to update their company, will be prompted to update their phone number (phone number is not mandatory)

## Remediation Strategy 
Rollback if needed.
