### PR TITLE
XMDEV-366: Update SASS to silence deprecation warning

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -14,31 +14,31 @@
 /*
  * Base styles (reset, typography)
  */
-@import "base/reset";
+@use "base/reset";
 
 /*
  * Layout components
  */
-@import "layout/page-structure";
-@import "layout/welcome-page";
+@use "layout/page-structure";
+@use "layout/welcome-page";
 
 /*
  * UI Components
  */
-@import "components/buttons";
-@import "components/forms";
-@import "components/tables";
-@import "components/navbar";
-@import "components/messages";
-@import "components/modals";
+@use "components/buttons";
+@use "components/forms";
+@use "components/tables";
+@use "components/navbar";
+@use "components/messages";
+@use "components/modals";
 
 /*
  * Page-specific styles
  */
-@import "pages/tabs";
+@use "pages/tabs";
 
 /*
  * Utilities (load last to override)
  */
-@import "utilities/helpers";
-@import "utilities/responsive";
+@use "utilities/helpers";
+@use "utilities/responsive";


### PR DESCRIPTION
## Description
There was a deprecation warning issued encouraging us to update our use of @import to @use for our sass stylesheets.

## Approach Taken
Update @import to @use.

## What Could Go Wrong?
If this change doesn't work for users, the styling may be off for users. This has been tested extensively so we believe this won't occur. 

## Remediation Strategy 
Rollback if needed.
