### PR TITLE
XMDEV-365: Disables create and new actions if user already has a company

### DIFF
--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -13,11 +13,11 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def new?
-    user.admin?
+    user.admin? && user.company.nil?
   end
 
   def create?
-    user.admin?
+    user.admin? && user.company.nil?
   end
 
   def edit?

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -1,20 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe CompanyPolicy, type: :policy do
-  let(:admin) { User.new(role: 'admin') }
+  let(:admin_without_company) { User.new(role: 'admin', company: nil) }
+  let(:admin_with_company) { User.new(role: 'admin', company: Company.new) }
   let(:driver) { User.new(role: 'driver') }
   let(:customer) { User.new(role: 'customer') }
 
-  let(:company) { Company.new } # Mock shipment object
-
+  let(:company) { Company.new }
 
   describe 'permissions' do
-    context 'when the user is an admin' do
-      let(:user) { admin }
+    context 'when the user is an admin without a company' do
+      let(:user) { admin_without_company }
       subject { described_class.new(user, company) }
 
       it { expect(subject.new?).to be true }
       it { expect(subject.create?).to be true }
+      it { expect(subject.edit?).to be true }
+      it { expect(subject.update?).to be true }
+    end
+
+    context 'when the user is an admin with a company' do
+      let(:user) { admin_with_company }
+      subject { described_class.new(user, company) }
+
+      it { expect(subject.new?).to be false }
+      it { expect(subject.create?).to be false }
       it { expect(subject.edit?).to be true }
       it { expect(subject.update?).to be true }
     end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "/companies", type: :request do
-  let(:valid_user) { create(:user, role: "admin") }
+  let(:valid_user) { create(:user, role: "admin", company: nil) }
   let(:non_admin_user) { create(:user) }
 
   let(:company) { create(:company) }
@@ -49,6 +49,22 @@ RSpec.describe "/companies", type: :request do
       it "renders a successful response" do
         get new_company_url
         expect(response).to be_successful
+      end
+
+      context 'when the user already has a company' do
+        before do
+          valid_user.update!(company: company)
+        end
+
+        it 'redirects to the root path' do
+          get new_company_url
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'renders the correct flash alert' do
+          get new_company_url
+          expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+        end
       end
     end
 


### PR DESCRIPTION
## Description
Users were able to get to the new or create company action and create a new company object. This could cause a collection of issues! If a user created a new company after they created drivers, all those drivers would be tied to the old company and not the new! 😨 

## Approach Taken
Updated the policy object to prevent users from recreating their company

## What Could Go Wrong?
We take ANY changes to any policies very seriously since they deal specifically with access control within the application. We consider this kind of change high risk. As with any user policy change, there is a chance that access control could be impacted. Therefore, we monitor these kinds of changes are rigorously test before deploying.

## Remediation Strategy 
Rollback if needed.
