### PR TITLE
On shipments show organize delivery shipments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@
 dump.rdb
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+
+.vscode/settings.json

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -56,7 +56,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @shipment.delivery_shipments.each do |del_ship| %>
+    <% @shipment.delivery_shipments.order(created_at: :desc).each do |del_ship| %>
     <tr>
       <td>
         <% company = @shipment.company || del_ship.delivery&.user&.company %>

--- a/docs/user_journeys/customer_monitoring_shipment.md
+++ b/docs/user_journeys/customer_monitoring_shipment.md
@@ -50,16 +50,15 @@ The customer wants to track the progress of their shipment to understand how far
 ## Emotions
 
 - 🟢 Feels well-informed by email notifications about shipment activity
+- 🟢 Appreciates the straighforward and clear layout of the shipment details page, showing incremental deliveries
 - 🟢 Appreciates being able to track the shipment and identify and contact the carrier
 - 🟡 Frustrated by difficulty identifying the correct shipment on the index page
-- 🟡 Confused by delivery events being displayed out of order
 
 ---
 
 ## Pain Points
 
 - The shipment index page includes columns that aren't helpful for most users; customers typically search by recipient and send date _(XMDEV-341)_
-- The shipment show page does not always sort delivery events chronologically, causing confusion _(XMDEV-342)_
 
 ---
 


### PR DESCRIPTION
## Description
This is a bug fix for rendering the delivery shipments within the shipment show view. They were being shown out of order.

## Approach Taken
Adds an order call to the delivery shipments within the view.

## What Could Go Wrong?
Nothing major. If this change didn't work, then delivery shipments would be shown out of order on the front end. Which, all things considered isn't the worst thing in the world.

## Remediation Strategy 
Rollback if needed.
