### PR TITLE
XMDEV-362: Remove all deliveries delivered question from delivery clo…

### DIFF
--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -20,8 +20,8 @@
       <!-- Modal Component -->
       <div class="modal-overlay" data-complete-delivery-target="modal">
         <div class="truck-load-modal-content">
-          <h3>Delivery Complete Confirmation</h3>
-          <p>All shipments are successfully closed?</p>
+          <h3>Confirmation</h3>
+          <p>Mark this delivery as complete?</p>
 
           <div class="truck-load-modal-buttons">
             <button type="button" class="button primary-button" data-complete-delivery-target="confirmBtn" data-action="click->complete-delivery#showOdometerInput">

--- a/docs/user_journeys/trucking_company_marking_delivery_complete.md
+++ b/docs/user_journeys/trucking_company_marking_delivery_complete.md
@@ -71,7 +71,7 @@ After completing all associated deliveries, the driver (or admin) needs to forma
 
 ## Opportunities
 
-- **XMDEV-362**: If the delivery is not eligible for completion (e.g., shipments still open), disable or hide the `Mark Complete` button until criteria are met
+- None currently reported in this workflow
 
 ---
 


### PR DESCRIPTION
## Description
In the mark delivery complete modal, users were prompted if `All shipments had been delivered?`. This was strange since in order to click the button that brings up this modal, all shipments need to be delivered. 

## Approach Taken
Update the HTML in the modal.

## What Could Go Wrong?
Nothing major. This is purely a copy update.

## Remediation Strategy 
NA
