### PR TITLE
XMDEV-367: Update redirection to dashboard path instead of root path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,12 +27,12 @@ class ApplicationController < ActionController::Base
     end
 
     def handle_record_not_found
-      redirect_to(root_path, alert: "Not authorized.")
+      redirect_to(dashboard_path, alert: "Not authorized.")
     end
 
     def user_not_authorized
       flash[:alert] = "You are not authorized to perform this action."
-      redirect_to(request.referrer || root_path)
+      redirect_to(request.referrer || dashboard_path)
     end
 
   protected

--- a/app/views/companies/edit.html.erb
+++ b/app/views/companies/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="page-header">
   <h1 class="page-title">Edit Company Details</h1>
-  <%= link_to 'Back', root_path, class: 'button secondary-button' %>
+  <%= link_to 'Back', dashboard_path, class: 'button secondary-button' %>
 </div>
 
 <div class="form-container">

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -1,6 +1,6 @@
 <div class="page-header">
   <h1 class="page-title">New Company</h1>
-  <%= link_to 'Back', root_path, class: 'button secondary-button' %>
+  <%= link_to 'Back', dashboard_path, class: 'button secondary-button' %>
 </div>
 
 <div class="form-container">

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe "/admin", type: :request do
         sign_in non_admin_user
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get admin_index_path
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders an error message" do

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe "/companies", type: :request do
           valid_user.update!(company: company)
         end
 
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get new_company_url
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders the correct flash alert' do
@@ -221,9 +221,9 @@ RSpec.describe "/companies", type: :request do
     end
 
     describe 'GET /new' do
-      it 'redirects to the root path' do
+      it 'redirects to the dashboard path' do
         get new_company_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it 'renders with an error message' do
@@ -239,9 +239,9 @@ RSpec.describe "/companies", type: :request do
         }.not_to change(Company, :count)
       end
 
-      it 'redirects to the root path' do
+      it 'redirects to the dashboard path' do
         post companies_url, params: { company: valid_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it 'renders with an error message' do
@@ -253,9 +253,9 @@ RSpec.describe "/companies", type: :request do
     describe 'GET /edit' do
       before { non_admin_user.update!(company: company) }
 
-      it 'redirects to the root path' do
+      it 'redirects to the dashboard path' do
         get edit_company_url(company)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it 'renders with an error message' do
@@ -277,9 +277,9 @@ RSpec.describe "/companies", type: :request do
         expect(company.name).not_to eq("Updated Company")
       end
 
-      it 'redirects to the root path' do
+      it 'redirects to the dashboard path' do
         patch company_url(company), params: { company: new_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it 'renders with an error message' do

--- a/spec/requests/deliveries_spec.rb
+++ b/spec/requests/deliveries_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe "/deliveries", type: :request do
       end
 
       context "when the delivery does not belong to the users company" do
-        it "redirects to the root" do
+        it "redirects to the dashboard" do
           get delivery_url(other_delivery)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it "shows an alert saying not authorized" do
@@ -195,9 +195,9 @@ RSpec.describe "/deliveries", type: :request do
       end
 
       context "when the delivery does not belong to the users company" do
-        it "redirects to the root" do
+        it "redirects to the dashboard" do
           post close_delivery_url(other_delivery), params: { odometer_reading: valid_odometer_reading }
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it "shows an alert saying not authorized" do
@@ -311,9 +311,9 @@ RSpec.describe "/deliveries", type: :request do
     end
 
     describe "GET /index" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get deliveries_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -323,9 +323,9 @@ RSpec.describe "/deliveries", type: :request do
     end
 
     describe "GET /show" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get deliveries_url(delivery)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -335,9 +335,9 @@ RSpec.describe "/deliveries", type: :request do
     end
 
     describe "POST /close" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         post close_delivery_url(delivery)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -347,9 +347,9 @@ RSpec.describe "/deliveries", type: :request do
     end
 
     describe "GET /load_truck" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get load_truck_deliveries_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -359,9 +359,9 @@ RSpec.describe "/deliveries", type: :request do
     end
 
     describe "GET /start" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get start_deliveries_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do

--- a/spec/requests/driver_management_spec.rb
+++ b/spec/requests/driver_management_spec.rb
@@ -139,9 +139,9 @@ RSpec.describe "/driver_managements", type: :request do
       end
 
       context "when the driver is from another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get edit_driver_management_url(other_driver)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -231,9 +231,9 @@ RSpec.describe "/driver_managements", type: :request do
       end
 
       context "when the driver is from another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           post reset_password_driver_management_url(other_driver)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -250,9 +250,9 @@ RSpec.describe "/driver_managements", type: :request do
     end
 
     describe "GET /new" do
-      it "redirects non-admin users to the root path" do
+      it "redirects non-admin users to the dashboard path" do
         get new_driver_management_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -268,9 +268,9 @@ RSpec.describe "/driver_managements", type: :request do
         }.not_to change(User, :count)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         post driver_managements_url, params: { user: valid_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -280,9 +280,9 @@ RSpec.describe "/driver_managements", type: :request do
     end
 
     describe "GET /edit" do
-      it "redirects non-admin users to the root path" do
+      it "redirects non-admin users to the dashboard path" do
         get edit_driver_management_url(driver)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -298,9 +298,9 @@ RSpec.describe "/driver_managements", type: :request do
         expect(driver.first_name).not_to eq("Jane")
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         patch driver_management_url(driver), params: { user: new_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -323,9 +323,9 @@ RSpec.describe "/driver_managements", type: :request do
         }.not_to have_enqueued_mail(DriverMailer, :send_reset_password)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         post reset_password_driver_management_url(driver)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe "Forms", type: :request do
       context "when form exists" do
         let(:form) { create(:form, :maintenance, company: company) }
 
-        it "redirects to the root path" do
+        it "redirects to the dashboard path" do
           get show_modal_form_path(form)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it "renders an error message" do

--- a/spec/requests/shipment_action_preferences_spec.rb
+++ b/spec/requests/shipment_action_preferences_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe "/shipment_action_preferences", type: :request do
       end
 
       context "when the shipment action preference belongs to another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get edit_shipment_action_preference_url(other_company_preference)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -100,9 +100,9 @@ RSpec.describe "/shipment_action_preferences", type: :request do
     end
 
     describe "GET /edit" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get edit_shipment_action_preference_url(company_preference)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -118,9 +118,9 @@ RSpec.describe "/shipment_action_preferences", type: :request do
         expect(company_preference.shipment_status_id).not_to be_nil
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         patch shipment_action_preference_url(company_preference), params: { shipment_action_preference: new_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do

--- a/spec/requests/shipment_statuses_spec.rb
+++ b/spec/requests/shipment_statuses_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe "/shipment_statuses", type: :request do
       end
 
       context "when the shipment status belongs to another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get edit_shipment_status_url(other_shipment_status)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -176,9 +176,9 @@ RSpec.describe "/shipment_statuses", type: :request do
     end
 
     describe "GET /new" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get new_shipment_status_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -188,9 +188,9 @@ RSpec.describe "/shipment_statuses", type: :request do
     end
 
     describe "GET /edit" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get edit_shipment_status_url(shipment_status)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -206,9 +206,9 @@ RSpec.describe "/shipment_statuses", type: :request do
         }.not_to change(ShipmentStatus, :count)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         post shipment_statuses_url, params: { shipment_status: valid_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -224,9 +224,9 @@ RSpec.describe "/shipment_statuses", type: :request do
         expect(shipment_status.name).not_to eq("Delivered")
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         patch shipment_status_url(shipment_status), params: { shipment_status: new_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -242,9 +242,9 @@ RSpec.describe "/shipment_statuses", type: :request do
         }.not_to change(ShipmentStatus, :count)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         delete shipment_status_url(shipment_status)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe "/shipments", type: :request do
       context "when the shipment belongs to the user" do
         it "redirects to the shipments index" do
           post close_shipment_url(shipment)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it "shows an alert saying not authorized" do
@@ -364,9 +364,9 @@ RSpec.describe "/shipments", type: :request do
     end
 
     describe "POST #assign" do
-      it 'redirects to the root page' do
+      it 'redirects to the dashboard page' do
         post assign_shipments_url, params: { shipment_ids: [] }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -376,9 +376,9 @@ RSpec.describe "/shipments", type: :request do
     end
 
     describe "POST #assign_shipments_to_truck" do
-      it 'redirects to the root' do
+      it 'redirects to the dashboard' do
         post assign_shipments_to_truck_shipments_url, params: { shipment_ids: [], truck_id: nil }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -388,9 +388,9 @@ RSpec.describe "/shipments", type: :request do
     end
 
     describe "POST #initiate_delivery" do
-      it 'redirects to the root' do
+      it 'redirects to the dashboard' do
         post initiate_delivery_shipments_url, params: { truck_id: 1 }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -406,9 +406,9 @@ RSpec.describe "/shipments", type: :request do
     end
 
     describe 'GET #index' do
-      it 'redirects to the root page' do
+      it 'redirects to the dashboard page' do
         get shipments_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -475,9 +475,9 @@ RSpec.describe "/shipments", type: :request do
     end
 
     describe "GET #new" do
-      it 'redirects to the root page' do
+      it 'redirects to the dashboard page' do
         get new_shipment_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -490,9 +490,9 @@ RSpec.describe "/shipments", type: :request do
       context "when the shipment is unclaimed" do
         let!(:shipment) { create(:shipment, user: valid_user, company: nil) }
 
-        it 'redirects to the root page' do
+        it 'redirects to the dashboard page' do
           get edit_shipment_url(shipment)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it "shows an alert saying not authorized" do
@@ -541,9 +541,9 @@ RSpec.describe "/shipments", type: :request do
     describe "GET #copy" do
       let!(:claimed_shipment) { create(:shipment, user: valid_user, company: company, name: "Test Shipment") }
 
-      it 'redirects to the root page' do
+      it 'redirects to the dashboard page' do
         get copy_shipment_url(claimed_shipment)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -559,9 +559,9 @@ RSpec.describe "/shipments", type: :request do
       }.not_to change(Shipment, :count)
       end
 
-      it 'redirects to the root page' do
+      it 'redirects to the dashboard page' do
         post shipments_url, params: { shipment: valid_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "shows an alert saying not authorized" do
@@ -585,9 +585,9 @@ RSpec.describe "/shipments", type: :request do
             expect(shipment.name).not_to eq("Toys")
           end
 
-          it "redirects to the root path" do
+          it "redirects to the dashboard path" do
             patch shipment_url(shipment), params: { shipment: new_attributes }
-            expect(response).to redirect_to(root_path)
+            expect(response).to redirect_to(dashboard_path)
           end
         end
 
@@ -666,9 +666,9 @@ RSpec.describe "/shipments", type: :request do
             expect(shipment.name).not_to eq(nil)
           end
 
-          it 'redirects to the root page' do
+          it 'redirects to the dashboard page' do
             patch shipment_url(shipment), params: { shipment: invalid_attributes }
-            expect(response).to redirect_to(root_path)
+            expect(response).to redirect_to(dashboard_path)
           end
 
           it "shows an alert saying not authorized" do
@@ -846,7 +846,7 @@ RSpec.describe "/shipments", type: :request do
     end
 
     describe "DELETE #destroy" do
-      it 'redirects to the root page' do
+      it 'redirects to the dashboard page' do
         delete shipment_url(shipment)
         expect(response).to redirect_to(deliveries_path)
       end

--- a/spec/requests/trucks_spec.rb
+++ b/spec/requests/trucks_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe "/trucks", type: :request do
       end
 
       context "when the truck belongs to another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get truck_url(other_truck)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -133,9 +133,9 @@ RSpec.describe "/trucks", type: :request do
       end
 
       context "when the truck belongs to another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           get edit_truck_url(other_truck)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -228,9 +228,9 @@ RSpec.describe "/trucks", type: :request do
       end
 
       context "when the truck belongs to another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           delete truck_url(other_truck)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -292,9 +292,9 @@ RSpec.describe "/trucks", type: :request do
       end
 
       context "when the truck belongs to another company" do
-        it 'redirects to the root path' do
+        it 'redirects to the dashboard path' do
           post create_form_truck_url(other_truck), params: valid_form_attributes
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(dashboard_path)
         end
 
         it 'renders with an alert' do
@@ -311,9 +311,9 @@ RSpec.describe "/trucks", type: :request do
     end
 
     describe "GET /show" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get truck_url(truck)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -323,9 +323,9 @@ RSpec.describe "/trucks", type: :request do
     end
 
     describe "GET /new" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get new_truck_url
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -335,9 +335,9 @@ RSpec.describe "/trucks", type: :request do
     end
 
     describe "GET /edit" do
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         get truck_url(truck)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -353,9 +353,9 @@ RSpec.describe "/trucks", type: :request do
         }.not_to change(Truck, :count)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         post trucks_url, params: { truck: valid_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -371,9 +371,9 @@ RSpec.describe "/trucks", type: :request do
         expect(truck.make).not_to eq("Ford")
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         patch truck_url(truck), params: { truck: new_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -389,9 +389,9 @@ RSpec.describe "/trucks", type: :request do
         }.not_to change(Truck, :count)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         delete truck_url(truck)
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do
@@ -409,9 +409,9 @@ RSpec.describe "/trucks", type: :request do
         expect(truck.active).not_to eq(true)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the dashboard path" do
         post create_form_truck_url(truck), params: valid_form_attributes
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(dashboard_path)
       end
 
       it "renders the correct flash alert" do


### PR DESCRIPTION
## Description
For logged in users, they very rarely need to access the root of the application. We therefore opted to update the app to redirect to their dashboard page instead.

## Approach Taken
Update all redirections to the dashboard page.

## What Could Go Wrong?
Nothing major. This page consistently exists for all logged in users. 

## Remediation Strategy 
NA