### PR TITLE
XMDEV-335: Update copy on shipment action preference edit page to detail when action is triggered

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -9,6 +9,14 @@
   margin-bottom: 0.5rem;
 }
 
+.form-help-text {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #666;
+  font-style: italic;
+  line-height: 1.4;
+}
+
 .form-input {
   width: 95%;
   padding: 0.75rem;

--- a/app/helpers/shipment_action_preferences_helper.rb
+++ b/app/helpers/shipment_action_preferences_helper.rb
@@ -1,0 +1,12 @@
+module ShipmentActionPreferencesHelper
+  def action_explanation(action)
+    explanations = {
+      "claimed_by_company" => "This preference will be triggered when your company's bid for a shipment is accepted by the shipper.",
+      "loaded_onto_truck" => "This preference will be triggered when a shipment is loaded onto or assigned to a specific truck.",
+      "out_for_delivery" => "This preference will be triggered when the delivery is initiated after filling out the truck inspection checklist. This will signify the shipment is out for delivery.",
+      "successfully_delivered" => "This preference will be triggered when users click the 'Quick Close' button for a shipment that's out for delivery. This is meant to signify the shipment has been delivered successfully."
+    }
+
+    explanations[action] || "No explanation available for this action."
+  end
+end

--- a/app/views/shipment_action_preferences/_form.html.erb
+++ b/app/views/shipment_action_preferences/_form.html.erb
@@ -18,6 +18,7 @@
         value: "When #{preference.action.gsub('_', ' ')}", 
         class: 'form-input', 
         disabled: true %>
+  <p class="form-help-text"><%= action_explanation(preference.action) %></p>
 </div>
 
 <% unless statuses.empty? %>

--- a/docs/user_journeys/admin_managing_shipment_statuses.md
+++ b/docs/user_journeys/admin_managing_shipment_statuses.md
@@ -64,19 +64,19 @@ Each trucking company does things differently. They may have different steps or 
 
 - 🟢 Easy creation of status
 - 🟢 Shipment status automation—no additional manual work required
-- 🟡 Some confusion around when a particular workflow might apply
+- 🟢 Users are pleased by the clear explainations of when the status change actions will be triggered within the app.
 
 ---
 
 ## Pain Points
 
-- User may not know when the associated action is triggered within the app.
+- None currently reported in this workflow.
 
 ---
 
 ## Opportunities
 
-- Update the copy on the workflow action page to explain when a given action is triggered within the app (XMDEV-335).
+- None currently reported in this workflow.
 
 ---
 

--- a/spec/helpers/shipment_action_preferences_helper_spec.rb
+++ b/spec/helpers/shipment_action_preferences_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ShipmentActionPreferencesHelper, type: :helper do
+  describe '#action_explanation' do
+    context 'with known actions' do
+      it 'returns correct explanation for claimed_by_company' do
+        expected = "This preference will be triggered when your company's bid for a shipment is accepted by the shipper."
+        expect(helper.action_explanation('claimed_by_company')).to eq(expected)
+      end
+
+      it 'returns correct explanation for loaded_onto_truck' do
+        expected = "This preference will be triggered when a shipment is loaded onto or assigned to a specific truck."
+        expect(helper.action_explanation('loaded_onto_truck')).to eq(expected)
+      end
+
+      it 'returns correct explanation for out_for_delivery' do
+        expected = "This preference will be triggered when the delivery is initiated after filling out the truck inspection checklist. This will signify the shipment is out for delivery."
+        expect(helper.action_explanation('out_for_delivery')).to eq(expected)
+      end
+
+      it 'returns correct explanation for successfully_delivered' do
+        expected = "This preference will be triggered when users click the 'Quick Close' button for a shipment that's out for delivery. This is meant to signify the shipment has been delivered successfully."
+        expect(helper.action_explanation('successfully_delivered')).to eq(expected)
+      end
+    end
+
+    context 'with unknown or invalid actions' do
+      it 'returns fallback message for unknown action' do
+        expect(helper.action_explanation('unknown_action')).to eq('No explanation available for this action.')
+      end
+
+      it 'returns fallback message for nil action' do
+        expect(helper.action_explanation(nil)).to eq('No explanation available for this action.')
+      end
+
+      it 'returns fallback message for empty string' do
+        expect(helper.action_explanation('')).to eq('No explanation available for this action.')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Upon articulating and reviewing our user journeys, some users expressed confusion around when certain status actions would trigger. We therefore opted to update the app with explanations on the relevant pages to hopefully mitigate this issue.

## Approach Taken
Added a helper method that would return the appropriate copy for a given action.

## What Could Go Wrong?
Nothing major. We have edge cases accounted for.

## Remediation Strategy 
NA
