### PR TITLE
XMDEV-371: Fix flaky test to ensure robustness with array matching

### DIFF
--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Truck, type: :model do
       let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery) }
       let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery) }
       it "returns the open shipments" do
-        expect(valid_truck.current_shipments).to match_array([delivery_shipment1.shipment, delivery_shipment2.shipment])
+        expect(valid_truck.current_shipments).to match_array([ delivery_shipment1.shipment, delivery_shipment2.shipment ])
       end
     end
 


### PR DESCRIPTION
## Description
A test in our test suite was flaky. Therefore, this PR fixes it.

## Approach Taken
Update my use of `to eq` to `to match_array`. This doesn't consider order, therefore making the test more robust.

## What Could Go Wrong?
This is a fix for a flaky test. Things have already gone wrong! 😨 

## Remediation Strategy 
NA