### PR TITLE
XMDEV-359: Updates columns in delivery show page to show deliver by date and conditionally render sender address

### DIFF
--- a/app/views/deliveries/show.html.erb
+++ b/app/views/deliveries/show.html.erb
@@ -72,9 +72,12 @@
       <tr>
         <th>Status</th>
         <th>Name</th>
+        <% unless @delivery.in_progress? %>
         <th>Sender Address</th>
+        <% end %>
         <th>Receiver Address</th>
         <th>Weight</th>
+        <th>Deliver By</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -83,9 +86,12 @@
       <tr>
         <td><%= shipment.status %></td>
         <td><%= shipment.name %></td>
+        <% unless @delivery.in_progress? %>
         <td><%= shipment.sender_address %></td>
+        <% end %>
         <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
+        <td><%= shipment.deliver_by %></td>
         <td>
           <% if @delivery.in_progress? && @shipment_status%>
           <%= link_to 'Quick Close', close_shipment_path(shipment), 
@@ -113,6 +119,7 @@
         <th>Sender Address</th>
         <th>Receiver Address</th>
         <th>Weight</th>
+        <th>Deliver By</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -124,6 +131,7 @@
         <td><%= shipment.sender_address %></td>
         <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
+        <td><%= shipment.deliver_by %></td>
         <td>
           <%= link_to 'Show', shipment, class: 'action-link' %> |
           <%= link_to 'Edit', edit_shipment_path(shipment), class: 'action-link' %>

--- a/docs/user_journeys/driver_setting_a_delivery_to_closed.md
+++ b/docs/user_journeys/driver_setting_a_delivery_to_closed.md
@@ -72,7 +72,6 @@ As Peter completes the physical delivery of packages to their destination, he mu
 
 ## Opportunities
 
-- **XMDEV-359**: Hide receiver address on the Delivery Show page if delivery is in progress
 - **XMDEV-361**: Fix bug preventing delivery from closing after manual shipment closure
 
 ---


### PR DESCRIPTION
## Description
While investigating our user journeys, users wanted some of the columns to update depending on what status the delivery was in.

## Approach Taken
Update the columns in the delivery show page.

## What Could Go Wrong?
Nothing major. This is solely a frontend update to conditionally render some columns.

## Remediation Strategy 
NA
