### PR TITLE
XMDEV-389: Removes max width contraint from main-content window

### DIFF
--- a/app/assets/stylesheets/layout/_page-structure.scss
+++ b/app/assets/stylesheets/layout/_page-structure.scss
@@ -1,7 +1,6 @@
 /* Page Layout Styles */
 .main-content {
   padding: 2rem;
-  max-width: 1200px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Description
In order to provide an optimal experience on any device, we removed the max width property that constrained the main content. 

## Approach Taken
Removed the max width line from a stylesheet.

## What Could Go Wrong?
Nothing major. Simple styling change.

## Remediation Strategy 
NA
