### PR TITLE
Send email when truck maintenance due

### DIFF
--- a/app/jobs/deactivate_trucks_job.rb
+++ b/app/jobs/deactivate_trucks_job.rb
@@ -7,6 +7,7 @@ class DeactivateTrucksJob < ApplicationJob
 
       begin
         truck.update!(active: false) # Use update! to raise an error if it fails
+        TruckMailer.send_truck_maintenance_due_email(truck).deliver_later
         Rails.logger.info("✅ Truck ##{truck.id} deactivated successfully")
       rescue StandardError => e
         Rails.logger.error("❌ Failed to deactivate Truck ##{truck.id}: #{e.message}")

--- a/app/mailers/truck_mailer.rb
+++ b/app/mailers/truck_mailer.rb
@@ -1,0 +1,6 @@
+class TruckMailer < ApplicationMailer
+  def send_truck_maintenance_due_email(truck)
+    @truck = truck
+    mail(to: @truck.company.admin_emails, subject: "Truck Maintenance Due - #{@truck.display_name}")
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -16,4 +16,8 @@ class Company < ApplicationRecord
             with: /\A\+?[\d\s\-()]{10,20}\z/,
             message: "must be a valid phone number (can include +, -, space, parentheses)"
           }
+
+  def admin_emails
+    users.admins.pluck(:email)
+  end
 end

--- a/app/services/close_delivery.rb
+++ b/app/services/close_delivery.rb
@@ -31,7 +31,10 @@ class CloseDelivery < ApplicationService
   end
 
   def deactivate_truck_if_needed
-    @delivery.truck.deactivate! if @delivery.truck.should_deactivate?
+    if @delivery.truck.should_deactivate?
+      @delivery.truck.deactivate!
+      TruckMailer.send_truck_maintenance_due_email(@delivery.truck).deliver_later
+    end
   end
 
   def complete_delivery

--- a/app/views/truck_mailer/send_truck_maintenance_due_email.html.erb
+++ b/app/views/truck_mailer/send_truck_maintenance_due_email.html.erb
@@ -1,0 +1,46 @@
+<style type="text/css">
+  body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    line-height: 1.6;
+    font-size: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #09e80d;
+    margin-bottom: 10px;
+  }
+
+  .details-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+
+  .detail-value {
+    color: #336699;
+  }
+</style>
+
+<h1>Truck Maintenance Due</h1>
+<p>Hello Admin,</p>
+<p>This is a reminder that the following truck is due for maintenance. Please schedule the necessary service as soon as possible to ensure continued safe operation.</p>
+
+<h2>Truck Details</h2>
+<div class="details-container">
+  <p><strong>Make:</strong> <span class="detail-value"><%= @truck.make %></span></p>
+  <p><strong>Model:</strong> <span class="detail-value"><%= @truck.model %></span></p>
+  <p><strong>Year:</strong> <span class="detail-value"><%= @truck.year %></span></p>
+  <p><strong>License Plate:</strong> <span class="detail-value"><%= @truck.license_plate %></span></p>
+  <p><strong>VIN:</strong> <span class="detail-value"><%= @truck.vin %></span></p>
+  <p><strong>Mileage:</strong> <span class="detail-value"><%= @truck.mileage %> miles</span></p>
+  <p><strong>Weight:</strong> <span class="detail-value"><%= @truck.weight %> kg</span></p>
+  <p><strong>Dimensions (L×W×H):</strong> <span class="detail-value"><%= @truck.length %> × <%= @truck.width %> × <%= @truck.height %> cm</span></p>
+</div>
+
+<p>Thank you for truckin' along!</p>

--- a/docs/user_journeys/trucking_company_managing_truck_maintenance.md
+++ b/docs/user_journeys/trucking_company_managing_truck_maintenance.md
@@ -53,6 +53,7 @@ As trucks rack up mileage and time on the road, regular maintenance becomes crit
 
 - 🟢 Relieved and satisfied that the app proactively notified them of due maintenance
 - 🟢 Grateful for the quick, low-effort maintenance form process
+- 🟢 Grateful for the email notifications alerting for due truck maintenance
 - 🔴 Frustrated that **only admins** can complete maintenance tasks—drivers are often more aware of the truck’s actual condition
 
 ---
@@ -66,7 +67,6 @@ As trucks rack up mileage and time on the road, regular maintenance becomes crit
 ## Opportunities
 
 - **XMDEV-347**: Allow drivers to fill out and submit maintenance forms, increasing accuracy and reducing admin overhead
-- **XMDEV-348**: Implement email notifications for upcoming or overdue truck maintenance
 
 ---
 

--- a/spec/jobs/deactivate_trucks_job_spec.rb
+++ b/spec/jobs/deactivate_trucks_job_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe DeactivateTrucksJob, type: :job do
       expect(Rails.logger).to have_received(:info).with("✅ Truck ##{truck_high_mileage.id} deactivated successfully")
     end
 
+    it "sends an email for trucks that have been deactivated" do
+      expect { described_class.perform_now }
+        .to have_enqueued_mail(TruckMailer, :send_truck_maintenance_due_email)
+        .with(truck_old_inspection)
+    end
+
     it "ignores already inactive trucks" do
       expect { described_class.perform_now }
         .not_to change { truck_inactive.reload.active }

--- a/spec/mailers/previews/truck_mailer_preview.rb
+++ b/spec/mailers/previews/truck_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/truck_mailer_mailer
+class TruckMailerPreview < ActionMailer::Preview
+  def send_truck_maintenance_due_email
+    truck = FactoryBot.create(:truck)
+    TruckMailer.send_truck_maintenance_due_email(truck)
+  end
+end

--- a/spec/mailers/truck_mailer_spec.rb
+++ b/spec/mailers/truck_mailer_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe TruckMailer, type: :mailer do
   describe ".send_truck_maintenance_due_email" do
     let(:user) { create(:user, role: "admin") }
     let!(:truck) { create(:truck, company: user.company) }
+    let(:mail) { described_class.send_truck_maintenance_due_email(truck) }
+
 
     it "renders the headers" do
       expect(mail.subject).to eq("Truck Maintenance Due - #{truck.display_name}")
@@ -14,11 +16,11 @@ RSpec.describe TruckMailer, type: :mailer do
     it "renders the body with the truck attributes" do
       expect(mail.body.encoded).to include(truck.make)
       expect(mail.body.encoded).to include(truck.model)
-      expect(mail.body.encoded).to include(truck.year)
+      expect(mail.body.encoded).to include(truck.year.to_s)
       expect(mail.body.encoded).to include(truck.license_plate)
       expect(mail.body.encoded).to include(truck.vin)
-      expect(mail.body.encoded).to include(truck.mileage)
-      expect(mail.body.encoded).to include(truck.weight)
+      expect(mail.body.encoded).to include(truck.mileage.to_s)
+      expect(mail.body.encoded).to include(truck.weight.to_s)
     end
   end
 end

--- a/spec/mailers/truck_mailer_spec.rb
+++ b/spec/mailers/truck_mailer_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe TruckMailer, type: :mailer do
+  describe ".send_truck_maintenance_due_email" do
+    let(:user) { create(:user, role: "admin") }
+    let!(:truck) { create(:truck, company: user.company) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Truck Maintenance Due - #{truck.display_name}")
+      expect(mail.to).to eq([ user.email ])
+      expect(mail.from).to eq([ Rails.application.credentials.dig(:mailer, :default_from) || "from@example.com" ])
+    end
+
+    it "renders the body with the truck attributes" do
+      expect(mail.body.encoded).to include(truck.make)
+      expect(mail.body.encoded).to include(truck.model)
+      expect(mail.body.encoded).to include(truck.year)
+      expect(mail.body.encoded).to include(truck.license_plate)
+      expect(mail.body.encoded).to include(truck.vin)
+      expect(mail.body.encoded).to include(truck.mileage)
+      expect(mail.body.encoded).to include(truck.weight)
+    end
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -54,4 +54,20 @@ RSpec.describe Company, type: :model do
       end
     end
   end
+
+  describe '#admin_emails' do
+    let(:company) { create(:company) }
+
+    let!(:admin1) { create(:user, company: company, role: 'admin', email: 'admin1@example.com') }
+    let!(:admin2) { create(:user, company: company, role: 'admin', email: 'admin2@example.com') }
+    let!(:user)    { create(:user, company: company, role: 'driver', email: 'user@example.com') }
+
+    it 'returns only the emails of admin users' do
+      expect(company.admin_emails).to match_array([ 'admin1@example.com', 'admin2@example.com' ])
+    end
+
+    it 'does not include non-admin emails' do
+      expect(company.admin_emails).not_to include('user@example.com')
+    end
+  end
 end


### PR DESCRIPTION
## Description
Admins should be alerted when some of their trucks are due for maintenance. This PR adds a maintenance email reminder.

## Approach Taken
Added the mailer, updated the code to trigger at various times.

## What Could Go Wrong?
Nothing major. This change adds a mailer and has it triggered asynchronously at various times. Won't block user use.

## Remediation Strategy 
Rollback if needed.
