### PR TITLE
XMDEV-399: Updates redirect to dashboard page on user update

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -18,4 +18,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def after_sign_in_path_for(resource)
     dashboard_path
   end
+
+  def after_update_path_for(resource)
+    dashboard_path
+  end
 end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -2,11 +2,18 @@ require 'rails_helper'
 
 RSpec.describe "Users::RegistrationsController", type: :request do
   let(:valid_attributes) {
-    { email: "test@example.com", password: "password", password_confirmation: "password", first_name: "Frank", last_name: "Dillenger", drivers_license: "87654321" }
+    {
+      email: "test@example.com",
+      password: "password",
+      password_confirmation: "password",
+      first_name: "Frank",
+      last_name: "Dillenger",
+      drivers_license: "87654321"
+    }
   }
 
   let(:invalid_attributes) {
-    { email: "", password: "password", password_confirmation: "password" } # Invalid because email is blank
+    { email: "", password: "password", password_confirmation: "password" }
   }
 
   describe "GET /users/sign_up/customer" do
@@ -14,11 +21,17 @@ RSpec.describe "Users::RegistrationsController", type: :request do
       get new_customer_registration_url
       expect(response).to be_successful
     end
+
+    it "assigns a new user with role 'customer'" do
+      get new_customer_registration_url
+      expect(assigns(:user)).to be_a_new(User)
+      expect(assigns(:user).role).to eq("customer")
+    end
   end
 
   describe "POST /users" do
     context "with valid parameters" do
-      it "creates a new user" do
+      it "creates a new user with default role 'admin'" do
         expect {
           post user_registration_path, params: { user: valid_attributes }
         }.to change(User, :count).by(1)
@@ -27,7 +40,16 @@ RSpec.describe "Users::RegistrationsController", type: :request do
         expect(user.role).to eq("admin")
       end
 
-      it "redirects to the dashboard path" do
+      it "creates a new user with overridden role 'customer'" do
+        expect {
+          post user_registration_path, params: { user: valid_attributes.merge(role: "customer") }
+        }.to change(User, :count).by(1)
+
+        user = User.last
+        expect(user.role).to eq("customer")
+      end
+
+      it "redirects to the dashboard path after sign up" do
         post user_registration_path, params: { user: valid_attributes }
         expect(response).to redirect_to(dashboard_path)
       end
@@ -37,13 +59,46 @@ RSpec.describe "Users::RegistrationsController", type: :request do
       it "does not create a new user" do
         expect {
           post user_registration_path, params: { user: invalid_attributes }
-        }.to change(User, :count).by(0)
+        }.not_to change(User, :count)
       end
 
-      it "renders a response with 422 status (to display the 'new' template)" do
+      it "renders a response with 422 status" do
         post user_registration_path, params: { user: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
       end
+    end
+  end
+
+  describe "PUT /users" do
+    let(:user) { create(:user, password: "password") }
+
+    before do
+      sign_in user
+    end
+
+    it "updates the user password" do
+      put user_registration_path, params: {
+        user: {
+          current_password: "password",
+          password: "newpassword123",
+          password_confirmation: "newpassword123"
+        }
+      }
+
+      user.reload
+      expect(user.valid_password?("newpassword123")).to be true
+    end
+
+    it "redirects to dashboard" do
+      put user_registration_path, params: {
+        user: {
+          current_password: "password",
+          password: "newpassword123",
+          password_confirmation: "newpassword123"
+        }
+      }
+
+      expect(response).to redirect_to(dashboard_path)
     end
   end
 end


### PR DESCRIPTION
## Description
When users changed their password, they were being redirected to the root welcome page. This was less than idea because they were already signed in and that page prompts them to sign up. 

## Approach Taken
Simply overwrote one of the devise protected routes to redirect to the dashboard page.

## What Could Go Wrong?
Nothing really. This simply changes the default route redirection.

## Remediation Strategy 
NA
