### PR TITLE
XMDEV-361: Fix issue when manually updating a shipment status to closed

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -40,18 +40,14 @@ class ShipmentsController < ApplicationController
   # PATCH/PUT /shipments/1
   def update
     authorize @shipment
-    if @shipment.shipment_status&.closed
-      return redirect_to @shipment, alert: "Shipment is closed, and currently locked for edits."
-    end
 
-    if current_user.customer? && @shipment.shipment_status&.locked_for_customers
-      return redirect_to @shipment, alert: "Shipment is currently locked for edits."
-    end
+    service = UpdateShipment.new(@shipment, shipment_params, current_user)
+    result = service.run
 
-    if @shipment.update(shipment_params)
-      redirect_to @shipment, notice: "Shipment was successfully updated."
+    if result.success?
+      redirect_to @shipment, notice: result.message
     else
-      render :edit, status: :unprocessable_entity
+      redirect_to @shipment, alert: result.error
     end
   end
 

--- a/app/services/update_shipment.rb
+++ b/app/services/update_shipment.rb
@@ -1,0 +1,52 @@
+require "ostruct"
+
+class UpdateShipment < ApplicationService
+  def initialize(shipment, params, current_user)
+    @shipment = shipment
+    @params = params
+    @current_user = current_user
+  end
+
+  def run
+    return failure("Shipment is closed, and currently locked for edits.") if shipment_closed?
+    return failure("Shipment is currently locked for edits.") if shipment_locked_for_customer?
+
+    previous_status_id = @shipment.shipment_status_id
+    if @shipment.update(@params)
+      maybe_update_delivered_date(previous_status_id)
+      success("Shipment was successfully updated.")
+    else
+      failure(@shipment.errors.full_messages.join(", "))
+    end
+  rescue => e
+    failure("An error occurred while updating the shipment: #{e.message}")
+  end
+
+  private
+
+  def shipment_closed?
+    @shipment.shipment_status&.closed
+  end
+
+  def shipment_locked_for_customer?
+    @current_user.customer? && @shipment.shipment_status&.locked_for_customers
+  end
+
+  def maybe_update_delivered_date(previous_status_id)
+    new_status_id = @params[:shipment_status_id]
+    return unless new_status_id.present? && new_status_id.to_i != previous_status_id.to_i
+
+    new_status = ShipmentStatus.find_by(id: new_status_id)
+    if new_status&.closed
+      @shipment.latest_delivery_shipment&.update!(delivered_date: Time.now)
+    end
+  end
+
+  def success(message)
+    OpenStruct.new(success?: true, message: message)
+  end
+
+  def failure(error)
+    OpenStruct.new(success?: false, error: error)
+  end
+end

--- a/docs/user_journeys/driver_setting_a_delivery_to_closed.md
+++ b/docs/user_journeys/driver_setting_a_delivery_to_closed.md
@@ -60,22 +60,21 @@ As Peter completes the physical delivery of packages to their destination, he mu
 
 - 🟢 Pleased when Quick Close is available — fast and efficient
 - 🟢 Please with power behind manual process - able to manipulate all fields quickly
-- 🔴 Frustration from UI bugs or over-clicking
 
 ---
 
 ## Pain Points
 
-- A known bug prevents delivery from being properly closed if done manually
+- None currently reported in this workflow
 
 ---
 
 ## Opportunities
 
-- **XMDEV-361**: Fix bug preventing delivery from closing after manual shipment closure
+- None currently reported in this workflow
 
 ---
 
 ## Outcome
 
-At the end of this journey, the user successfully marked shipments as delivered, either via the streamlined **Quick Close** method or through the more detailed **manual update** process. While functional, the journey reveals opportunities to reduce friction and resolve bugs for a more seamless closing experience.
+At the end of this journey, the user successfully marked shipments as delivered, either via the streamlined **Quick Close** method or through the more detailed **manual update** process.

--- a/spec/requests/shipments_spec.rb
+++ b/spec/requests/shipments_spec.rb
@@ -279,14 +279,14 @@ RSpec.describe "/shipments", type: :request do
             expect(shipment.name).not_to eq(nil)
           end
 
-          it "responds with unprocessable_entity status" do
+          it "redirects to the shipment edit page" do
             patch shipment_url(shipment), params: { shipment: invalid_attributes }
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to redirect_to(shipment_url(shipment))
           end
 
-          it 're-renders the edit template' do
+          it "shows an alert saying the shipment was ot updated" do
             patch shipment_url(shipment), params: { shipment: invalid_attributes }
-            expect(response).to render_template(:edit)
+            expect(flash[:alert]).to eq("Name can't be blank, Sender name can't be blank, Sender address can't be blank, Receiver name can't be blank, Receiver address can't be blank, Weight can't be blank, Weight is not a number")
           end
         end
       end
@@ -687,14 +687,14 @@ RSpec.describe "/shipments", type: :request do
               expect(shipment.name).not_to eq(nil)
             end
 
-            it "responds with unprocessable_entity status" do
+            it "redirects to the shipment edit page" do
               patch shipment_url(shipment), params: { shipment: invalid_attributes }
-              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response).to redirect_to(shipment_url(shipment))
             end
 
-            it 're-renders the edit template' do
+            it "shows an alert saying the shipment was ot updated" do
               patch shipment_url(shipment), params: { shipment: invalid_attributes }
-              expect(response).to render_template(:edit)
+              expect(flash[:alert]).to eq("Sender address can't be blank, Receiver address can't be blank, Weight can't be blank, Weight is not a number")
             end
           end
 

--- a/spec/services/update_shipment_spec.rb
+++ b/spec/services/update_shipment_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe UpdateShipment do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create(:user) }
+  let(:company) { create(:company) }
+  let(:truck) { create(:truck, company: company) }
+  let(:shipment_status) { create(:shipment_status, company: company) }
+  let(:closed_status) { create(:shipment_status, company: company, closed: true) }
+  let(:locked_status) { create(:shipment_status, company: company, locked_for_customers: true) }
+  let(:delivery) { create(:delivery, truck: truck, user: user) }
+
+  let(:shipment) do
+    create(:shipment,
+           user: user,
+           company: company,
+           shipment_status: shipment_status)
+  end
+
+  describe '#run' do
+    context 'when shipment is closed' do
+      before do
+        shipment.update!(shipment_status: closed_status)
+      end
+
+      it 'returns failure with appropriate message' do
+        service = described_class.new(shipment, { name: 'Updated Name' }, user)
+        result = service.run
+
+        expect(result.success?).to be false
+        expect(result.error).to eq('Shipment is closed, and currently locked for edits.')
+      end
+    end
+
+    context 'when shipment is locked for customers' do
+      before do
+        shipment.update!(shipment_status: locked_status)
+      end
+
+      it 'returns failure for customer users' do
+        customer_user = create(:user, role: 'customer')
+        service = described_class.new(shipment, { name: 'Updated Name' }, customer_user)
+        result = service.run
+
+        expect(result.success?).to be false
+        expect(result.error).to eq('Shipment is currently locked for edits.')
+      end
+
+      it 'allows updates for non-customer users' do
+        driver_user = create(:user, role: 'driver', company: company)
+        service = described_class.new(shipment, { name: 'Updated Name' }, driver_user)
+        result = service.run
+
+        expect(result.success?).to be true
+        expect(shipment.reload.name).to eq('Updated Name')
+      end
+    end
+
+    context 'when status is updated to closed' do
+      let!(:delivery_shipment) do
+        create(:delivery_shipment,
+               delivery: delivery,
+               shipment: shipment)
+      end
+
+      it 'updates the delivered_date on the latest delivery shipment' do
+        travel_to Time.current do
+          service = described_class.new(shipment, { shipment_status_id: closed_status.id }, user)
+          result = service.run
+
+          expect(result.success?).to be true
+          expect(shipment.reload.shipment_status_id).to eq(closed_status.id)
+          expect(delivery_shipment.reload.delivered_date).to eq(Time.current)
+        end
+      end
+
+      it 'does not update delivered_date when status is not changed' do
+        # Update to closed status first
+        shipment.update!(shipment_status: closed_status)
+        original_delivered_date = delivery_shipment.delivered_date
+
+        # Now try to update other fields without changing status
+        service = described_class.new(shipment, { name: 'Updated Name' }, user)
+        result = service.run
+
+        expect(result.success?).to be false
+        expect(result.error).to eq('Shipment is closed, and currently locked for edits.')
+      end
+
+      it 'does not update delivered_date when status is changed to non-closed' do
+        new_status = create(:shipment_status, company: company, closed: false)
+        original_delivered_date = delivery_shipment.delivered_date
+
+        service = described_class.new(shipment, { shipment_status_id: new_status.id }, user)
+        result = service.run
+
+        expect(result.success?).to be true
+        expect(shipment.reload.shipment_status_id).to eq(new_status.id)
+        expect(delivery_shipment.reload.delivered_date).to eq(original_delivered_date)
+      end
+    end
+
+    context 'when update is successful' do
+      it 'returns success with appropriate message' do
+        service = described_class.new(shipment, { name: 'Updated Name' }, user)
+        result = service.run
+
+        expect(result.success?).to be true
+        expect(result.message).to eq('Shipment was successfully updated.')
+        expect(shipment.reload.name).to eq('Updated Name')
+      end
+    end
+
+    context 'when update fails validation' do
+      it 'returns failure with validation errors' do
+        service = described_class.new(shipment, { name: '' }, user)
+        result = service.run
+
+        expect(result.success?).to be false
+        expect(result.error).to include("Name can't be blank")
+      end
+    end
+
+    context 'when an exception occurs' do
+      it 'returns failure with error message' do
+        allow(shipment).to receive(:update).and_raise(StandardError.new('Database error'))
+
+        service = described_class.new(shipment, { name: 'Updated Name' }, user)
+        result = service.run
+
+        expect(result.success?).to be false
+        expect(result.error).to eq('An error occurred while updating the shipment: Database error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
While articulating our user journeys, we found a bug with updating a shipment to closed manually. This wouldn't allow the delivery to be closed.

## Approach Taken
Created a new, dedicated service focussed on updating shipment attributes.

## What Could Go Wrong?
This is a bug fix, so things have technically already gone wrong!

## Remediation Strategy 
NA.
