### PR TITLE
XMDEV-370: Update truck loading map to show current location of shipment

### DIFF
--- a/app/javascript/controllers/show_truck_loading_map_controller.js
+++ b/app/javascript/controllers/show_truck_loading_map_controller.js
@@ -23,12 +23,12 @@ export default class extends Controller {
 
   hasValidCoordinates(shipment) {
     return (
-      shipment.sender_latitude != null &&
-      shipment.sender_longitude != null &&
+      shipment.current_sender_latitude != null &&
+      shipment.current_sender_longitude != null &&
       shipment.receiver_latitude != null &&
       shipment.receiver_longitude != null &&
-      shipment.sender_latitude !== 0 &&
-      shipment.sender_longitude !== 0 &&
+      shipment.current_sender_latitude !== 0 &&
+      shipment.current_sender_longitude !== 0 &&
       shipment.receiver_latitude !== 0 &&
       shipment.receiver_longitude !== 0
     );
@@ -45,15 +45,15 @@ export default class extends Controller {
 
     this.shipments.forEach((shipment, index) => {
       if (this.hasValidCoordinates(shipment)) {
-        const senderMarker = L.marker([shipment.sender_latitude, shipment.sender_longitude]).addTo(map);
-        senderMarker.bindPopup(`<b>Pickup Location ${index + 1}</b><br>${shipment.sender_address}`);
+        const senderMarker = L.marker([shipment.current_sender_latitude, shipment.current_sender_longitude]).addTo(map);
+        senderMarker.bindPopup(`<b>Pickup Location ${index + 1}</b><br>${shipment.current_sender_address}`);
 
         const receiverMarker = L.marker([shipment.receiver_latitude, shipment.receiver_longitude]).addTo(map);
         receiverMarker.bindPopup(`<b>Delivery Location ${index + 1}</b><br>${shipment.receiver_address}`);
 
         // eslint-disable-next-line no-unused-vars
         const polyline = L.polyline([
-          [shipment.sender_latitude, shipment.sender_longitude],
+          [shipment.current_sender_latitude, shipment.current_sender_longitude],
           [shipment.receiver_latitude, shipment.receiver_longitude]
         ], {
           color: this.getRouteColor(index),
@@ -61,7 +61,7 @@ export default class extends Controller {
           opacity: 0.7
         }).addTo(map);
 
-        bounds.extend([shipment.sender_latitude, shipment.sender_longitude]);
+        bounds.extend([shipment.current_sender_latitude, shipment.current_sender_longitude]);
         bounds.extend([shipment.receiver_latitude, shipment.receiver_longitude]);
       }
     });

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -49,6 +49,21 @@ class Shipment < ApplicationRecord
     delivery_shipments.order(created_at: :desc).first
   end
 
+  def current_sender_address
+    return sender_address if latest_delivery_shipment.nil?
+    latest_delivery_shipment.receiver_address
+  end
+
+  def current_sender_latitude
+    return sender_latitude if latest_delivery_shipment.nil?
+    latest_delivery_shipment.receiver_latitude
+  end
+
+  def current_sender_longitude
+    return sender_longitude if latest_delivery_shipment.nil?
+    latest_delivery_shipment.receiver_longitude
+  end
+
   private
 
   def geocode_sender

--- a/app/views/deliveries/load_truck.html.erb
+++ b/app/views/deliveries/load_truck.html.erb
@@ -1,7 +1,7 @@
 <h1>Deliveries</h1>
 
 <% if @unassigned_shipments.any? %>
-<div style="height: 500px; width: 100%;" data-controller="show-truck-loading-map" data-show-truck-loading-map-shipments-json-value='<%= raw @unassigned_shipments.to_json(only: [:id], methods: [:sender_latitude, :sender_longitude, :receiver_latitude, :receiver_longitude, :sender_address, :receiver_address]) %>'>
+<div style="height: 500px; width: 100%;" data-controller="show-truck-loading-map" data-show-truck-loading-map-shipments-json-value='<%= raw @unassigned_shipments.to_json(only: [:id], methods: [:current_sender_latitude, :current_sender_longitude, :receiver_latitude, :receiver_longitude, :current_sender_address, :receiver_address]) %>'>
 </div>
 <h2>Truck Loading</h2>
 <div data-controller="truck-loading-modal">
@@ -33,7 +33,7 @@
         <td><%= check_box_tag 'shipment_ids[]', shipment.id %></td>
         <td><%= shipment.status %></td>
         <td><%= shipment.name %></td>
-        <td><%= shipment.sender_address %></td>
+        <td><%= shipment.current_sender_address %></td>
         <td><%= shipment.receiver_address %></td>
         <td><%= shipment.weight %></td>
         <td><%= shipment.deliver_by %></td>

--- a/spec/javascript/controllers/show_truck_loading_map_controller.test.js
+++ b/spec/javascript/controllers/show_truck_loading_map_controller.test.js
@@ -53,11 +53,11 @@ describe("ShowTruckLoadingMapController", () => {
       <div 
         data-controller="show-truck-loading-map"
         data-show-truck-loading-map-shipments-json-value='[{
-          "sender_latitude": 40.7128,
-          "sender_longitude": -74.0060,
+          "current_sender_latitude": 40.7128,
+          "current_sender_longitude": -74.0060,
           "receiver_latitude": 34.0522,
           "receiver_longitude": -118.2437,
-          "sender_address": "New York, NY",
+          "current_sender_address": "New York, NY",
           "receiver_address": "Los Angeles, CA"
         }]'>
       </div>
@@ -104,8 +104,8 @@ describe("ShowTruckLoadingMapController", () => {
         <div 
           data-controller="show-truck-loading-map"
           data-show-truck-loading-map-shipments-json-value='[{
-            "sender_latitude": 0,
-            "sender_longitude": 0,
+            "current_sender_latitude": 0,
+            "current_sender_longitude": 0,
             "receiver_latitude": 0,
             "receiver_longitude": 0
           }]'>
@@ -122,8 +122,8 @@ describe("ShowTruckLoadingMapController", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-truck-loading-map");
       
       const validShipment = {
-        sender_latitude: 40.7128,
-        sender_longitude: -74.0060,
+        current_sender_latitude: 40.7128,
+        current_sender_longitude: -74.0060,
         receiver_latitude: 34.0522,
         receiver_longitude: -118.2437
       };
@@ -135,8 +135,8 @@ describe("ShowTruckLoadingMapController", () => {
       const controller = application.getControllerForElementAndIdentifier(container, "show-truck-loading-map");
 
       const invalidShipment = {
-        sender_latitude: 0,
-        sender_longitude: -74.0060,
+        current_sender_latitude: 0,
+        current_sender_longitude: -74.0060,
         receiver_latitude: 34.0522,
         receiver_longitude: -118.2437
       };

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -196,6 +196,66 @@ RSpec.describe Shipment, type: :model do
     end
   end
 
+  describe "#current_sender_address" do
+    describe "when there are no delivery shipments" do
+      it "returns the original sender address" do
+        expect(valid_shipment.current_sender_address).to eq(valid_shipment.sender_address)
+      end
+    end
+
+    describe "when there are delivery shipments" do
+      let!(:delivery_shipment) do
+        create(:delivery_shipment,
+               shipment: valid_shipment,
+               receiver_address: "456 Delivery Street, Los Angeles, CA")
+      end
+
+      it "returns the receiver address from the latest delivery shipment" do
+        expect(valid_shipment.current_sender_address).to eq("456 Delivery Street, Los Angeles, CA")
+      end
+    end
+  end
+
+  describe "#current_sender_latitude" do
+    describe "when there are no delivery shipments" do
+      it "returns the original sender latitude" do
+        expect(valid_shipment.current_sender_latitude).to eq(valid_shipment.sender_latitude)
+      end
+    end
+
+    describe "when there are delivery shipments" do
+      let!(:delivery_shipment) do
+        create(:delivery_shipment,
+               shipment: valid_shipment,
+               receiver_latitude: 40.7128)
+      end
+
+      it "returns the receiver latitude from the latest delivery shipment" do
+        expect(valid_shipment.current_sender_latitude).to eq(40.7128)
+      end
+    end
+  end
+
+  describe "#current_sender_longitude" do
+    describe "when there are no delivery shipments" do
+      it "returns the original sender longitude" do
+        expect(valid_shipment.current_sender_longitude).to eq(valid_shipment.sender_longitude)
+      end
+    end
+
+    describe "when there are delivery shipments" do
+      let!(:delivery_shipment) do
+        create(:delivery_shipment,
+               shipment: valid_shipment,
+               receiver_longitude: -74.006)
+      end
+
+      it "returns the receiver longitude from the latest delivery shipment" do
+        expect(valid_shipment.current_sender_longitude).to eq(-74.006)
+      end
+    end
+  end
+
   ## Geocoding Tests
   describe "geocoding" do
     describe "sender address geocoding" do


### PR DESCRIPTION
## Description
The truck loading page was showing the total shipment path even after a shipment was partially delivered. This PR changes that to show the current location of a shipment.

## Approach Taken
I added a couple new methods to the model that will list the current information for a given shipment.

## What Could Go Wrong?
Nothing major. Tests are passing. Proper error handling is in place. 

## Remediation Strategy 
NA
