### PR TITLE
XMDEV-356: Adds earliest deliver by date to deliveries start page

### DIFF
--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -47,6 +47,10 @@ class Truck < ApplicationRecord
     current_shipments.reduce(0.0) { |curr_weight, shipment| curr_weight + shipment.weight }
   end
 
+  def earliest_due_date
+    current_shipments.minimum(:deliver_by) || "No shipments"
+  end
+
   def latest_delivery
     deliveries.active.order(created_at: :desc).first
   end

--- a/app/views/deliveries/start.html.erb
+++ b/app/views/deliveries/start.html.erb
@@ -21,6 +21,7 @@
         <th># of Shipments</th>
         <th>Current Volume</th>
         <th>Current Weight</th>
+        <th>Earliest Delivery</th>
         <th class="center-text">Available?</th>
         <th class="center-text">Actions</>
       </tr>
@@ -32,6 +33,7 @@
         <td><%= truck.current_shipments.count%></td>
         <td><%= truck.current_volume / 1_000_000 %> m<sup>3</sup> / <%=truck.volume / 1_000_000%>m<sup>3</sup></td>
         <td><%= truck.current_weight %> kg / <%=truck.weight%> kg</td>
+        <td><%= truck.earliest_due_date %>
         <td class="center-text">
           <% if truck.available? %>
           ✔️

--- a/docs/user_journeys/trucking_company_starting_a_delivery.md
+++ b/docs/user_journeys/trucking_company_starting_a_delivery.md
@@ -66,7 +66,6 @@ Once trucks have been successfully loaded with shipments, the next step in the d
 
 ## Opportunities
 
-- **XMDEV-356**: Update deliveries start page to show earliest scheduled shipment delivery time
 - **XMDEV-354**: Add map to the Delivery Show page for better spatial awarenessform
 
 ---

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -193,6 +193,50 @@ RSpec.describe Truck, type: :model do
     end
   end
 
+  describe "#earliest_due_date" do
+    context "when there are shipments with different deliver_by dates" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+      let!(:shipment1) { create(:shipment, deliver_by: 1.week.from_now.to_date) }
+      let!(:shipment2) { create(:shipment, deliver_by: 2.weeks.from_now.to_date) }
+      let!(:shipment3) { create(:shipment, deliver_by: 3.days.from_now.to_date) }
+
+      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, shipment: shipment1) }
+      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, shipment: shipment2) }
+      let!(:delivery_shipment3) { create(:delivery_shipment, delivery: delivery, shipment: shipment3) }
+
+      it "returns the earliest deliver_by date" do
+        expect(valid_truck.earliest_due_date).to eq(3.days.from_now.to_date)
+      end
+    end
+
+    context "when there are shipments with the same deliver_by date" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+      let!(:shipment1) { create(:shipment, deliver_by: 1.week.from_now.to_date) }
+      let!(:shipment2) { create(:shipment, deliver_by: 1.week.from_now.to_date) }
+
+      let!(:delivery_shipment1) { create(:delivery_shipment, delivery: delivery, shipment: shipment1) }
+      let!(:delivery_shipment2) { create(:delivery_shipment, delivery: delivery, shipment: shipment2) }
+
+      it "returns the deliver_by date" do
+        expect(valid_truck.earliest_due_date).to eq(1.week.from_now.to_date)
+      end
+    end
+
+    context "when there are no delivery shipments" do
+      let!(:delivery) { create(:delivery, truck: valid_truck) }
+
+      it "returns 'No shipments'" do
+        expect(valid_truck.earliest_due_date).to eq("No shipments")
+      end
+    end
+
+    context "when there is no delivery" do
+      it "returns 'No shipments'" do
+        expect(valid_truck.earliest_due_date).to eq("No shipments")
+      end
+    end
+  end
+
   describe "#current_volume" do
     let!(:delivery) { create(:delivery, truck: valid_truck) }
 


### PR DESCRIPTION
## Description
While articulating our user stories, users said that having the earliest delivery by date in the deliveries start page would be helpful. It would remind drivers that they needed to get a move on!

## Approach Taken
Added a new instance method in the model, that's then used in the view.

## What Could Go Wrong?
Nothing major. Simply adds new information to a view.

## Remediation Strategy 
NA
