### PR TITLE
XMDEV-343: Adds offers mailer

### DIFF
--- a/app/mailers/offer_mailer.rb
+++ b/app/mailers/offer_mailer.rb
@@ -1,0 +1,22 @@
+class OfferMailer < ApplicationMailer
+  # Notifies shipment owner that they've received a new offer
+  def offer_received(offer_id)
+    @offer = Offer.find_by(id: offer_id)
+    @shipment = @offer.shipment
+    mail(to: @shipment.user.email, subject: "You've received a new offer for your shipment")
+  end
+
+  # Notifies company admins that their offer was rejected
+  def offer_rejected(offer_id)
+    @offer = Offer.find_by(id: offer_id)
+    @shipment = @offer.shipment
+    mail(to: @offer.company.admin_emails, subject: "Your offer was rejected")
+  end
+
+  # Notifies company admins that their offer was accepted
+  def offer_accepted(offer_id)
+    @offer = Offer.find_by(id: offer_id)
+    @shipment = @offer.shipment
+    mail(to: @offer.company.admin_emails, subject: "Your offer was accepted!")
+  end
+end

--- a/app/views/offer_mailer/offer_accepted.html.erb
+++ b/app/views/offer_mailer/offer_accepted.html.erb
@@ -1,0 +1,38 @@
+<style type="text/css">
+  body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    line-height: 1.6;
+    font-size: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #09e80d;
+    margin-bottom: 10px;
+  }
+
+  .details-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+
+  .detail-value {
+    color: #336699;
+  }
+</style>
+
+<h1>Your Offer Was Accepted!</h1>
+<p>Hello,</p>
+<p>Congratulations! Your offer for shipment <strong><%= @shipment.name %></strong> was accepted by the shipment owner.</p>
+<div class="details-container">
+  <p><strong>Price:</strong> <span class="detail-value">$<%= @offer.price %></span></p>
+  <p><strong>Notes:</strong> <span class="detail-value"><%= @offer.notes.presence || 'None' %></span></p>
+</div>
+<p>Please log in to your dashboard to view the shipment details and next steps.</p>
+<p>Thank you for truckin' along!</p>

--- a/app/views/offer_mailer/offer_received.html.erb
+++ b/app/views/offer_mailer/offer_received.html.erb
@@ -1,0 +1,39 @@
+<style type="text/css">
+  body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    line-height: 1.6;
+    font-size: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #09e80d;
+    margin-bottom: 10px;
+  }
+
+  .details-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+
+  .detail-value {
+    color: #336699;
+  }
+</style>
+
+<h1>New Offer Received</h1>
+<p>Hello <%= @shipment.user.display_name %>,</p>
+<p>You have received a new offer for your shipment: <strong><%= @shipment.name %></strong>.</p>
+<div class="details-container">
+  <p><strong>Offered by:</strong> <span class="detail-value"><%= @offer.company.name %></span></p>
+  <p><strong>Price:</strong> <span class="detail-value">$<%= @offer.price %></span></p>
+  <p><strong>Notes:</strong> <span class="detail-value"><%= @offer.notes.presence || 'None' %></span></p>
+</div>
+<p>Please log in to your dashboard to review and take action on this offer.</p>
+<p>Thank you for truckin' along!</p>

--- a/app/views/offer_mailer/offer_rejected.html.erb
+++ b/app/views/offer_mailer/offer_rejected.html.erb
@@ -1,0 +1,38 @@
+<style type="text/css">
+  body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    line-height: 1.6;
+    font-size: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #09e80d;
+    margin-bottom: 10px;
+  }
+
+  .details-container {
+    padding: 15px;
+    background-color: #f5f5f5;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+
+  .detail-value {
+    color: #336699;
+  }
+</style>
+
+<h1>Your Offer Was Rejected</h1>
+<p>Hello,</p>
+<p>Your offer for shipment <strong><%= @shipment.name %></strong> was rejected by the shipment owner.</p>
+<div class="details-container">
+  <p><strong>Price:</strong> <span class="detail-value">$<%= @offer.price %></span></p>
+  <p><strong>Notes:</strong> <span class="detail-value"><%= @offer.notes.presence || 'None' %></span></p>
+</div>
+<p>You can log in to your dashboard to view more details or submit a new offer if desired.</p>
+<p>Thank you for truckin' along!</p>

--- a/docs/user_journeys/customer_monitoring_shipment.md
+++ b/docs/user_journeys/customer_monitoring_shipment.md
@@ -64,7 +64,7 @@ The customer wants to track the progress of their shipment to understand how far
 
 ## Opportunities
 
-- Maintain and improve shipment-claimed email notifications _(XMDEV-343)_
+- None currently reported in this workflow
 
 ---
 

--- a/spec/mailers/offer_mailer_spec.rb
+++ b/spec/mailers/offer_mailer_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe OfferMailer, type: :mailer do
+  let(:company) { create(:company) }
+  let(:admin) { create(:user, :admin, company: company) }
+  let(:customer) { create(:user, :customer) }
+  let(:shipment) { create(:shipment, user: customer, company: company) }
+  let(:offer) { create(:offer, shipment: shipment, company: company, price: 123.45, notes: "Special offer note") }
+
+  describe "offer_received" do
+    subject(:mail) { described_class.offer_received(offer.id).deliver_now }
+
+    it "sends to the shipment owner" do
+      expect(mail.to).to eq([ shipment.user.email ])
+    end
+
+    it "has the correct subject" do
+      expect(mail.subject).to include("received a new offer")
+    end
+
+    it "includes offer details in the body" do
+      expect(mail.body.encoded).to include(offer.company.name)
+      expect(mail.body.encoded).to include("$123.45")
+      expect(mail.body.encoded).to include("Special offer note")
+    end
+  end
+
+  describe "offer_rejected" do
+    subject(:mail) { described_class.offer_rejected(offer.id).deliver_now }
+
+    before { admin } # ensure admin exists for company
+
+    it "sends to all company admins" do
+      expect(mail.to).to match_array(company.admin_emails)
+    end
+
+    it "has the correct subject" do
+      expect(mail.subject).to include("rejected")
+    end
+
+    it "includes offer details in the body" do
+      expect(mail.body.encoded).to include(shipment.name)
+      expect(mail.body.encoded).to include("$123.45")
+      expect(mail.body.encoded).to include("Special offer note")
+    end
+  end
+
+  describe "offer_accepted" do
+    subject(:mail) { described_class.offer_accepted(offer.id).deliver_now }
+
+    before { admin } # ensure admin exists for company
+
+    it "sends to all company admins" do
+      expect(mail.to).to match_array(company.admin_emails)
+    end
+
+    it "has the correct subject" do
+      expect(mail.subject).to include("accepted")
+    end
+
+    it "includes offer details in the body" do
+      expect(mail.body.encoded).to include(shipment.name)
+      expect(mail.body.encoded).to include("$123.45")
+      expect(mail.body.encoded).to include("Special offer note")
+    end
+  end
+end

--- a/spec/mailers/previews/offer_mailer_preview.rb
+++ b/spec/mailers/previews/offer_mailer_preview.rb
@@ -1,0 +1,29 @@
+# Preview all emails at http://localhost:3000/rails/mailers/offer_mailer_mailer
+class OfferMailerPreview < ActionMailer::Preview
+  def offer_received
+    company = FactoryBot.create(:company)
+    admin = FactoryBot.create(:user, :admin, company: company)
+    customer = FactoryBot.create(:user, :customer)
+    shipment = FactoryBot.create(:shipment, user: customer, company: company, name: "Preview Shipment")
+    offer = FactoryBot.create(:offer, shipment: shipment, company: company, price: 123.45, notes: "Special offer note")
+    OfferMailer.offer_received(offer.id)
+  end
+
+  def offer_rejected
+    company = FactoryBot.create(:company)
+    admin = FactoryBot.create(:user, :admin, company: company)
+    customer = FactoryBot.create(:user, :customer)
+    shipment = FactoryBot.create(:shipment, user: customer, company: company, name: "Preview Shipment")
+    offer = FactoryBot.create(:offer, :rejected, shipment: shipment, company: company, price: 123.45, notes: "Special offer note")
+    OfferMailer.offer_rejected(offer.id)
+  end
+
+  def offer_accepted
+    company = FactoryBot.create(:company)
+    admin = FactoryBot.create(:user, :admin, company: company)
+    customer = FactoryBot.create(:user, :customer)
+    shipment = FactoryBot.create(:shipment, user: customer, company: company, name: "Preview Shipment")
+    offer = FactoryBot.create(:offer, :accepted, shipment: shipment, company: company, price: 123.45, notes: "Special offer note")
+    OfferMailer.offer_accepted(offer.id)
+  end
+end


### PR DESCRIPTION
## Description
This PR adds all emails associated with offers. Customers get notified when they receive offers, and admins of companies get notified when their offers are accepted or rejected.

## Approach Taken
Adds a new dedicated offers mailer and styled all views.

## What Could Go Wrong?
This change is thoroughly tested. No cause for concern. Net new functionality

## Remediation Strategy 
Rollback if needed.
