### PR TITLE
XMDEV-419: Fix lint_js dependancy for create-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [test, test_js, scan_ruby, scan_js, lint]
+    needs: [test, test_js, scan_ruby, scan_js, lint, lint_js]
     if: startsWith(github.head_ref, 'release-') && success()
     permissions:
       contents: write


### PR DESCRIPTION
## Description
Noticed that lint_js was not required for create-release. It should be.

## Approach Taken
Adds the job as a dependancy.

## What Could Go Wrong?
Nothing zero risk PR.

## Remediation Strategy 
NA
