### PR TITLE
Differentiate shipments and dashboard

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -38,6 +38,7 @@
  */
 @use "pages/tabs";
 @use "pages/companies";
+@use "pages/dashboard";
 
 /*
  * Utilities (load last to override)

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -1,0 +1,561 @@
+// Dashboard Styles
+// ================
+
+.dashboard-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.dashboard-header {
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.dashboard-header h2 {
+  color: #333;
+  margin-bottom: 5px;
+}
+
+.dashboard-subtitle {
+  color: #666;
+  font-size: 16px;
+}
+
+// Metrics Grid
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.metric-card {
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.metric-icon {
+  font-size: 2em;
+  opacity: 0.8;
+}
+
+.metric-number {
+  font-size: 2em;
+  font-weight: bold;
+  color: #09e80d;
+  margin: 0;
+}
+
+.metric-label {
+  color: #666;
+  margin: 0;
+  font-size: 14px;
+}
+
+// Quick Actions
+.quick-actions {
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  margin-bottom: 30px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.quick-actions h3 {
+  margin-bottom: 15px;
+  color: #333;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.action-button {
+  padding: 12px 24px;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.action-button.primary {
+  background: #09e80d;
+  color: white;
+}
+
+.action-button.primary:hover {
+  background: #07c00b;
+}
+
+.action-button.secondary {
+  background: #f8f9fa;
+  color: #333;
+  border: 1px solid #dee2e6;
+}
+
+.action-button.secondary:hover {
+  background: #e9ecef;
+}
+
+// Status Overview
+.status-overview {
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  margin-bottom: 30px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.status-overview h3 {
+  margin-bottom: 15px;
+  color: #333;
+}
+
+.status-cards {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.status-card {
+  background: #f8f9fa;
+  border-radius: 6px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 100px;
+}
+
+.status-card.empty {
+  opacity: 0.6;
+}
+
+.status-name {
+  font-size: 12px;
+  color: #666;
+  text-align: center;
+  margin-bottom: 5px;
+}
+
+.status-count {
+  font-size: 1.5em;
+  font-weight: bold;
+  color: #09e80d;
+}
+
+// Dashboard Sections
+.dashboard-sections {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+  margin-bottom: 30px;
+}
+
+.dashboard-section {
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.section-header h3 {
+  margin: 0;
+  color: #333;
+}
+
+.view-all-link {
+  color: #09e80d;
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
+// Recent Shipments
+.recent-shipments {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.shipment-card {
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 15px;
+  background: #f8f9fa;
+}
+
+.shipment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.shipment-header h4 {
+  margin: 0;
+  color: #333;
+}
+
+.shipment-status {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.shipment-status.ready { 
+  background: #d4edda; 
+  color: #155724; 
+}
+
+.shipment-status.in-transit { 
+  background: #fff3cd; 
+  color: #856404; 
+}
+
+.shipment-status.delivered { 
+  background: #d1ecf1; 
+  color: #0c5460; 
+}
+
+.shipment-status.no-status { 
+  background: #f8d7da; 
+  color: #721c24; 
+}
+
+.shipment-details p {
+  margin: 5px 0;
+  font-size: 14px;
+  color: #666;
+}
+
+.shipment-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+// Deadlines
+.deadline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.deadline-item {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 15px;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  background: #f8f9fa;
+}
+
+.deadline-date {
+  text-align: center;
+  min-width: 60px;
+}
+
+.deadline-date .day {
+  display: block;
+  font-size: 1.5em;
+  font-weight: bold;
+  color: #09e80d;
+}
+
+.deadline-date .month {
+  display: block;
+  font-size: 12px;
+  color: #666;
+  text-transform: uppercase;
+}
+
+.deadline-content {
+  flex: 1;
+}
+
+.deadline-content h4 {
+  margin: 0 0 5px 0;
+  color: #333;
+}
+
+.deadline-content p {
+  margin: 0 0 5px 0;
+  font-size: 14px;
+  color: #666;
+}
+
+.days-remaining {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.days-remaining.urgent { 
+  color: #dc3545; 
+}
+
+.days-remaining.warning { 
+  color: #ffc107; 
+}
+
+.days-remaining.normal { 
+  color: #28a745; 
+}
+
+.deadline-action {
+  margin-left: auto;
+}
+
+// Empty States
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: #666;
+}
+
+.empty-state p {
+  margin-bottom: 15px;
+}
+
+// Offers Summary
+.offers-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  background: #fff3cd;
+  border-radius: 8px;
+  border: 1px solid #ffeaa7;
+}
+
+.offer-stats {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.offer-count {
+  font-size: 2em;
+  font-weight: bold;
+  color: #856404;
+}
+
+.offer-label {
+  color: #856404;
+  font-size: 14px;
+}
+
+.offer-actions {
+  margin-left: auto;
+}
+
+// Driver Dashboard Specific Styles
+// ==============================
+
+.recent-deliveries {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.delivery-card {
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 15px;
+  background: #f8f9fa;
+}
+
+.delivery-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.delivery-header h4 {
+  margin: 0;
+  color: #333;
+}
+
+.delivery-status {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.delivery-status.scheduled { 
+  background: #d1ecf1; 
+  color: #0c5460; 
+}
+
+.delivery-status.in_progress { 
+  background: #fff3cd; 
+  color: #856404; 
+}
+
+.delivery-status.completed { 
+  background: #d4edda; 
+  color: #155724; 
+}
+
+.delivery-status.cancelled { 
+  background: #f8d7da; 
+  color: #721c24; 
+}
+
+.delivery-details p {
+  margin: 5px 0;
+  font-size: 14px;
+  color: #666;
+}
+
+.delivery-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+.fleet-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.truck-card {
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 15px;
+  background: #f8f9fa;
+}
+
+.truck-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.truck-header h4 {
+  margin: 0;
+  color: #333;
+}
+
+.truck-status {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.truck-status.active { 
+  background: #d4edda; 
+  color: #155724; 
+}
+
+.truck-status.maintenance { 
+  background: #f8d7da; 
+  color: #721c24; 
+}
+
+.truck-details p {
+  margin: 5px 0;
+  font-size: 14px;
+  color: #666;
+}
+
+.truck-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+.maintenance-section {
+  margin-top: 30px;
+}
+
+.maintenance-table {
+  overflow-x: auto;
+}
+
+.active-delivery-alert {
+  background: #fff3cd;
+  border: 1px solid #ffeaa7;
+  margin-top: 30px;
+}
+
+.active-delivery-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+}
+
+.delivery-info h4 {
+  margin: 0 0 10px 0;
+  color: #856404;
+}
+
+.delivery-info p {
+  margin: 5px 0;
+  color: #856404;
+}
+
+.delivery-actions {
+  margin-left: auto;
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .dashboard-sections {
+    grid-template-columns: 1fr;
+  }
+  
+  .metrics-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  .action-buttons {
+    flex-direction: column;
+  }
+  
+  .deadline-item {
+    flex-direction: column;
+    text-align: center;
+  }
+  
+  .deadline-action {
+    margin-left: 0;
+    margin-top: 10px;
+  }
+  
+  .active-delivery-summary {
+    flex-direction: column;
+    text-align: center;
+  }
+  
+  .delivery-actions {
+    margin-left: 0;
+    margin-top: 15px;
+  }
+} 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -25,20 +25,18 @@ class DashboardController < ApplicationController
     else
       @deliveries = Delivery.for_user(current_user).includes(:truck, :shipments)
 
+      @total_deliveries = @deliveries.size
+      @active_deliveries = @deliveries.active.size
+      @scheduled_deliveries = @deliveries.scheduled.size
+      @completed_deliveries = @deliveries.completed.size
+      @recent_deliveries = @deliveries.order(created_at: :desc).first(5)
+
       @trucks = Truck.for_company(current_company).includes(:deliveries, :shipments)
 
       @total_trucks = @trucks.size
-      @total_deliveries = @deliveries.size
-      @completed_deliveries = @deliveries.completed.size
       @trucks_needing_maintenance = @trucks.count { |t| !t.active }
-
       @active_trucks = @trucks.count { |t| t.active }
       @available_trucks = @trucks.count { |t| t.available? }
-
-      @active_deliveries = @deliveries.active.size
-      @scheduled_deliveries = @deliveries.scheduled.size
-
-      @recent_deliveries = @deliveries.order(created_at: :desc).first(5)
       @fleet_overview_trucks = @trucks.first(5)
 
       @active_delivery = current_user.active_delivery

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,10 +3,45 @@ class DashboardController < ApplicationController
 
   def index
     if current_user.customer?
-      @shipments = Shipment.for_user(current_user).order(deliver_by: :asc)
+      @shipments = Shipment.for_user(current_user).includes(:company).order(deliver_by: :asc)
+
+      @total_shipments = @shipments.size
+      @pending_shipments = @shipments.count { |s| s.company_id.nil? }
+      @claimed_shipments = @total_shipments - @pending_shipments
+      @due_this_week_shipments = @shipments.count { |s| s.deliver_by.present? && s.deliver_by <= 7.days.from_now }
+
+      @status_counts = @shipments.group_by(&:status).transform_values(&:size)
+
+      @recent_shipments = @shipments.first(5)
+
+      @upcoming_shipments = @shipments
+                              .select { |s| s.deliver_by.present? && s.deliver_by <= 14.days.from_now }
+                              .sort_by(&:deliver_by)
+                              .first(5)
+
+      @pending_offers = Offer.joins(:shipment)
+                             .where(shipments: { user_id: current_user.id }, status: :issued)
+
     else
-      @deliveries = Delivery.for_user(current_user)
-      @trucks = Truck.for_company(current_company)
+      @deliveries = Delivery.for_user(current_user).includes(:truck, :shipments)
+
+      @trucks = Truck.for_company(current_company).includes(:deliveries, :shipments)
+
+      @total_trucks = @trucks.size
+      @total_deliveries = @deliveries.size
+      @completed_deliveries = @deliveries.completed.size
+      @trucks_needing_maintenance = @trucks.count { |t| !t.active }
+
+      @active_trucks = @trucks.count { |t| t.active }
+      @available_trucks = @trucks.count { |t| t.available? }
+
+      @active_deliveries = @deliveries.active.size
+      @scheduled_deliveries = @deliveries.scheduled.size
+
+      @recent_deliveries = @deliveries.order(created_at: :desc).first(5)
+      @fleet_overview_trucks = @trucks.first(5)
+
+      @active_delivery = current_user.active_delivery
     end
   end
 end

--- a/app/views/dashboard/_customer.html.erb
+++ b/app/views/dashboard/_customer.html.erb
@@ -1,49 +1,174 @@
-<div class="page-header">
-  <h3>My Customer Shipments</h3>
-  <%= link_to 'Create New Shipment', new_shipment_path, class: 'button primary-button' %>
-</div>
-<% if @shipments.present? %>
-<table class="styled-table">
-  <thead>
-    <tr>
-      <th>Company</th>
-      <th>Status</th>
-      <th>Name</th>
-      <th>Sender</th>
-      <th>Receiver</th>
-      <th>Weight</th>
-      <th>Deliver By</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @shipments.each do |shipment| %>
-    <tr>
-      <td><%= shipment&.company&.name %></td>
-      <td><%= shipment.status %></td>
-      <td><%= shipment.name %></td>
-      <td><%= shipment.sender_name %></td>
-      <td><%= shipment.receiver_name %></td>
-      <td><%= shipment.weight %></td>
-      <td><%= shipment.deliver_by %></td>
-      <td>
-        <%= link_to 'Show', shipment, class: 'action-link' %> |
-        <%= link_to 'Edit', edit_shipment_path(shipment), class: 'action-link' %> |
-        <%= link_to 'Copy', copy_shipment_path(shipment), class: 'action-link' %>
-        <% unless shipment.claimed? %>
-        | <%= link_to 'Destroy', shipment, method: :delete, data: { confirm: 'Are you sure?' }, class: 'action-link danger-link' %>
-        <% end %>
-      </td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
-<% else %>
-<div class="empty-state-container">
-  <div class="empty-state-content">
-    <h4>Seems a little quiet here...</h4>
-    <p>Head over to the shipments page to get some shipments.... Truckin' Along!</p>
-    <%= link_to "Create First Shipment", new_shipment_path, class: "primary-button" %>
+<div class="dashboard-container">
+  <!-- Dashboard Header -->
+  <div class="dashboard-header">
+    <h2>Welcome back, <%= current_user.first_name %>!</h2>
+    <p class="dashboard-subtitle">Here's what's happening with your shipments today</p>
   </div>
+
+  <!-- Key Metrics -->
+  <div class="metrics-grid">
+    <div class="metric-card">
+      <div class="metric-icon">📦</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @total_shipments %></h3>
+        <p class="metric-label">Total Shipments</p>
+      </div>
+    </div>
+
+    <div class="metric-card">
+      <div class="metric-icon">⏳</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @pending_shipments %></h3>
+        <p class="metric-label">Pending Shipments</p>
+      </div>
+    </div>
+
+    <div class="metric-card">
+      <div class="metric-icon">🚛</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @claimed_shipments %></h3>
+        <p class="metric-label">Claimed Shipments</p>
+      </div>
+    </div>
+
+    <div class="metric-card">
+      <div class="metric-icon">📅</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @due_this_week_shipments %></h3>
+        <p class="metric-label">Due This Week</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Quick Actions -->
+  <div class="quick-actions">
+    <h3>Quick Actions</h3>
+    <div class="action-buttons">
+      <%= link_to 'Create New Shipment', new_shipment_path, class: 'action-button primary' %>
+      <%= link_to 'View All Shipments', shipments_path, class: 'action-button secondary' %>
+      <%= link_to 'Check Offers', offers_path, class: 'action-button secondary' %>
+    </div>
+  </div>
+
+  <!-- Status Overview -->
+  <div class="status-overview">
+    <h3>Shipment Status Overview</h3>
+    <div class="status-cards">
+      <% if @status_counts.any? %>
+      <% @status_counts.each do |status, count| %>
+      <div class="status-card">
+        <span class="status-name"><%= status || 'No Status' %></span>
+        <span class="status-count"><%= count %></span>
+      </div>
+      <% end %>
+      <% else %>
+      <div class="status-card empty">
+        <span class="status-name">No shipments yet</span>
+        <span class="status-count">0</span>
+      </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Recent Activity & Upcoming Deadlines -->
+  <div class="dashboard-sections">
+    <!-- Recent Shipments -->
+    <div class="dashboard-section">
+      <div class="section-header">
+        <h3>Recent Shipments</h3>
+        <%= link_to 'View All', shipments_path, class: 'view-all-link' %>
+      </div>
+
+      <% if @shipments.present? %>
+      <div class="recent-shipments">
+        <% @recent_shipments.each do |shipment| %>
+        <div class="shipment-card">
+          <div class="shipment-header">
+            <h4><%= shipment.name %></h4>
+            <span class="shipment-status <%= shipment.status&.downcase&.gsub(/\s+/, '-') || 'no-status' %>">
+              <%= shipment.status || 'No Status' %>
+            </span>
+          </div>
+          <div class="shipment-details">
+            <p><strong>From:</strong> <%= shipment.sender_name %></p>
+            <p><strong>To:</strong> <%= shipment.receiver_name %></p>
+            <p><strong>Weight:</strong> <%= shipment.weight %> kg</p>
+            <p><strong>Due:</strong> <%= shipment.deliver_by&.strftime("%b %d, %Y") %></p>
+            <% if shipment.company %>
+            <p><strong>Carrier:</strong> <%= shipment.company.name %></p>
+            <% end %>
+          </div>
+          <div class="shipment-actions">
+            <%= link_to 'View Details', shipment_path(shipment), class: 'action-link' %>
+            <% unless shipment.claimed? %>
+            <%= link_to 'Edit', edit_shipment_path(shipment), class: 'action-link' %>
+            <% end %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+      <% else %>
+      <div class="empty-state">
+        <p>No shipments yet. Create your first shipment to get started!</p>
+        <%= link_to 'Create First Shipment', new_shipment_path, class: 'primary-button' %>
+      </div>
+      <% end %>
+    </div>
+
+    <!-- Upcoming Deadlines -->
+    <div class="dashboard-section">
+      <div class="section-header">
+        <h3>Upcoming Deadlines</h3>
+        <%= link_to 'View All', shipments_path, class: 'view-all-link' %>
+      </div>
+
+      <% if @upcoming_shipments.any? %>
+      <div class="deadline-list">
+        <% @upcoming_shipments.each do |shipment| %>
+        <div class="deadline-item">
+          <div class="deadline-date">
+            <span class="day"><%= shipment.deliver_by.day %></span>
+            <span class="month"><%= shipment.deliver_by.strftime("%b") %></span>
+          </div>
+          <div class="deadline-content">
+            <h4><%= shipment.name %></h4>
+            <p><%= shipment.receiver_name %> • <%= shipment.deliver_by.strftime("%B %d, %Y") %></p>
+            <% days_until = (shipment.deliver_by - Date.current).to_i %>
+            <span class="days-remaining <%= days_until <= 3 ? 'urgent' : days_until <= 7 ? 'warning' : 'normal' %>">
+              <%= pluralize(days_until, 'day') %> remaining
+            </span>
+          </div>
+          <div class="deadline-action">
+            <%= link_to 'View', shipment_path(shipment), class: 'action-link' %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+      <% else %>
+      <div class="empty-state">
+        <p>No upcoming deadlines. All caught up!</p>
+      </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Pending Offers Summary -->
+  <% if @pending_offers.any? %>
+  <div class="dashboard-section">
+    <div class="section-header">
+      <h3>Pending Offers</h3>
+      <%= link_to 'View All Offers', offers_path, class: 'view-all-link' %>
+    </div>
+
+    <div class="offers-summary">
+      <div class="offer-stats">
+        <span class="offer-count"><%= @pending_offers.count %></span>
+        <span class="offer-label">offers waiting for your review</span>
+      </div>
+      <div class="offer-actions">
+        <%= link_to 'Review Offers', offers_path, class: 'primary-button' %>
+      </div>
+    </div>
+  </div>
+  <% end %>
 </div>
-<% end %>

--- a/app/views/dashboard/_driver.html.erb
+++ b/app/views/dashboard/_driver.html.erb
@@ -1,97 +1,245 @@
-<h3>Completed Trips</h3>
-<% if @deliveries.present? %>
-<table class="styled-table">
-  <thead>
-    <tr>
-      <th>Status</th>
-      <th># of Shipments</th>
-      <th>Current Volume</th>
-      <th>Current Weight</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody id="my-shipments">
-    <% @deliveries.each do |delivery| %>
-    <tr>
-      <td><%= delivery.status.gsub('_', ' ').capitalize %></td>
-      <td><%= delivery.shipments.count%></td>
-      <td><%= delivery.volume / 1_000_000 %> m<sup>3</sup></td>
-      <td><%= delivery.weight %> kg</td>
-      <td>
-        <%= link_to 'Show', delivery, class: 'action-link' %>
-      </td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
-<% else %>
-<div class="empty-state-container">
-  <div class="empty-state-content">
-    <h4>Seems a little quiet here...</h4>
-    <p>Head over to the deliveries page to start.... Truckin' Along!</p>
-    <%= link_to "Start First Delivery", start_deliveries_path, class: "primary-button" %>
+<div class="dashboard-container">
+  <!-- Dashboard Header -->
+  <div class="dashboard-header">
+    <h2>Welcome back, <%= current_user.first_name %>!</h2>
+    <p class="dashboard-subtitle">Here's your delivery overview and fleet status</p>
   </div>
-</div>
-<% end %>
 
-<br />
+  <!-- Key Metrics -->
+  <div class="metrics-grid">
+    <div class="metric-card">
+      <div class="metric-icon">🚛</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @total_trucks %></h3>
+        <p class="metric-label">Total Trucks</p>
+      </div>
+    </div>
 
-<h3>Truck Maintenance</h3>
-<% if @trucks.present? %>
-<div data-controller="create-maintenance">
-  <div id="maintenance-modal" class="modal hidden">
-    <%= render 'forms/maintenance_form'%>
+    <div class="metric-card">
+      <div class="metric-icon">📦</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @total_deliveries %></h3>
+        <p class="metric-label">Total Deliveries</p>
+      </div>
+    </div>
+
+    <div class="metric-card">
+      <div class="metric-icon">✅</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @completed_deliveries %></h3>
+        <p class="metric-label">Completed Deliveries</p>
+      </div>
+    </div>
+
+    <div class="metric-card">
+      <div class="metric-icon">🔧</div>
+      <div class="metric-content">
+        <h3 class="metric-number"><%= @trucks_needing_maintenance %></h3>
+        <p class="metric-label">Trucks Needing Maintenance</p>
+      </div>
+    </div>
   </div>
-  <table class="styled-table">
-    <thead>
-      <tr>
-        <th>Make</th>
-        <th>Model</th>
-        <th>Year</th>
-        <th>Mileage</th>
-        <th>License Plate</th>
-        <th>Status</th>
-        <th>Actions</th>
-        <th>Maintenance</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @trucks.each do |truck| %>
-      <tr>
-        <td><%= truck.make %></td>
-        <td><%= truck.model %></td>
-        <td><%= truck.year %></td>
-        <td><%= truck.mileage %></td>
-        <td><%= truck.license_plate %></td>
-        <td>
-          <% if truck.active %>
-          <span class="status-active">Active</span>
-          <% else %>
-          <span class="status-inactive">Maintenance Required</span>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to 'View Details', truck, class: 'action-link' %>
-        </td>
-        <td>
-          <% if !truck.active %>
-          <button class="button warning-button" data-action="click->create-maintenance#open" data-modal-truck-id-value="<%= truck.id %>">
-            Complete Maintenance
-          </button>
-          <% else %>
-          <span class="status-active">Up to Date</span>
-          <% end %>
-        </td>
-      </tr>
+
+  <!-- Quick Actions -->
+  <div class="quick-actions">
+    <h3>Quick Actions</h3>
+    <div class="action-buttons">
+      <%= link_to 'Start Delivery', start_deliveries_path, class: 'action-button primary' %>
+      <%= link_to 'View All Deliveries', deliveries_path, class: 'action-button secondary' %>
+      <%= link_to 'Load Truck', load_truck_deliveries_path, class: 'action-button secondary' %>
+    </div>
+  </div>
+
+  <!-- Current Status -->
+  <div class="status-overview">
+    <h3>Current Status</h3>
+    <div class="status-cards">
+      <div class="status-card">
+        <span class="status-name">Active Trucks</span>
+        <span class="status-count"><%= @active_trucks %></span>
+      </div>
+      <div class="status-card">
+        <span class="status-name">Available Trucks</span>
+        <span class="status-count"><%= @available_trucks %></span>
+      </div>
+      <div class="status-card">
+        <span class="status-name">Active Deliveries</span>
+        <span class="status-count"><%= @active_deliveries %></span>
+      </div>
+      <div class="status-card">
+        <span class="status-name">Scheduled Deliveries</span>
+        <span class="status-count"><%= @scheduled_deliveries %></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Recent Activity & Truck Maintenance -->
+  <div class="dashboard-sections">
+    <!-- Recent Deliveries -->
+    <div class="dashboard-section">
+      <div class="section-header">
+        <h3>Recent Deliveries</h3>
+        <%= link_to 'View All', deliveries_path, class: 'view-all-link' %>
+      </div>
+
+      <% if @recent_deliveries.present? %>
+      <div class="recent-deliveries">
+        <% @recent_deliveries.each do |delivery| %>
+        <div class="delivery-card">
+          <div class="delivery-header">
+            <h4>Delivery #<%= delivery.id %></h4>
+            <span class="delivery-status <%= delivery.status %>">
+              <%= delivery.status.gsub('_', ' ').capitalize %>
+            </span>
+          </div>
+          <div class="delivery-details">
+            <p><strong>Truck:</strong> <%= delivery.truck&.display_name %></p>
+            <p><strong>Shipments:</strong> <%= delivery.shipments.count %></p>
+            <p><strong>Volume:</strong> <%= (delivery.volume / 1_000_000).round(2) %> m³</p>
+            <p><strong>Weight:</strong> <%= delivery.weight.round(1) %> kg</p>
+            <p><strong>Created:</strong> <%= delivery.created_at.strftime("%b %d, %Y") %></p>
+          </div>
+          <div class="delivery-actions">
+            <%= link_to 'View Details', delivery_path(delivery), class: 'action-link' %>
+            <% if delivery.active? %>
+            <%= link_to 'Continue', delivery_path(delivery), class: 'action-link' %>
+            <% end %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+      <% else %>
+      <div class="empty-state">
+        <p>No deliveries yet. Start your first delivery to get going!</p>
+        <%= link_to 'Start First Delivery', start_deliveries_path, class: 'primary-button' %>
+      </div>
       <% end %>
-    </tbody>
-  </table>
-</div>
-<% else %>
-<div class="empty-state-container">
-  <div class="empty-state-content">
-    <h4>No trucks available</h4>
-    <p>Contact your administrator to add trucks to your fleet.</p>
+    </div>
+
+    <!-- Fleet Overview -->
+    <div class="dashboard-section">
+      <div class="section-header">
+        <h3>Fleet Overview</h3>
+      </div>
+
+      <% if @fleet_overview_trucks.present? %>
+      <div class="fleet-overview">
+        <% @fleet_overview_trucks.each do |truck| %>
+        <div class="truck-card">
+          <div class="truck-header">
+            <h4><%= truck.display_name %></h4>
+            <span class="truck-status <%= truck.active? ? 'active' : 'maintenance' %>">
+              <%= truck.active? ? 'Active' : 'Maintenance Required' %>
+            </span>
+          </div>
+          <div class="truck-details">
+            <p><strong>Mileage:</strong> <%= number_with_delimiter(truck.mileage) %> km</p>
+            <p><strong>Capacity:</strong> <%= (truck.volume / 1_000_000).round(2) %> m³</p>
+            <p><strong>Max Weight:</strong> <%= truck.weight %> kg</p>
+            <p><strong>Available:</strong> <%= truck.available? ? 'Yes' : 'No' %></p>
+            <% if truck.current_shipments.any? %>
+            <p><strong>Current Load:</strong> <%= truck.current_shipments.count %> shipments</p>
+            <% end %>
+          </div>
+          <div class="truck-actions">
+            <%= link_to 'View Details', truck_path(truck), class: 'action-link' %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+      <% else %>
+      <div class="empty-state">
+        <p>No trucks available. Contact your administrator to add trucks to your fleet.</p>
+      </div>
+      <% end %>
+    </div>
   </div>
+
+  <!-- Truck Maintenance Section (Preserved from original) -->
+  <div class="dashboard-section maintenance-section">
+    <div class="section-header">
+      <h3>Truck Maintenance</h3>
+    </div>
+
+    <% if @trucks.present? %>
+    <div data-controller="create-maintenance">
+      <div id="maintenance-modal" class="modal hidden">
+        <%= render 'forms/maintenance_form'%>
+      </div>
+
+      <div class="maintenance-table">
+        <table class="styled-table">
+          <thead>
+            <tr>
+              <th>Make</th>
+              <th>Model</th>
+              <th>Year</th>
+              <th>Mileage</th>
+              <th>License Plate</th>
+              <th>Status</th>
+              <th>Actions</th>
+              <th>Maintenance</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @trucks.each do |truck| %>
+            <tr>
+              <td><%= truck.make %></td>
+              <td><%= truck.model %></td>
+              <td><%= truck.year %></td>
+              <td><%= number_with_delimiter(truck.mileage) %></td>
+              <td><%= truck.license_plate %></td>
+              <td>
+                <% if truck.active %>
+                <span class="status-active">Active</span>
+                <% else %>
+                <span class="status-inactive">Maintenance Required</span>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to 'View Details', truck, class: 'action-link' %>
+              </td>
+              <td>
+                <% if !truck.active %>
+                <button class="button warning-button" data-action="click->create-maintenance#open" data-modal-truck-id-value="<%= truck.id %>">
+                  Complete Maintenance
+                </button>
+                <% else %>
+                <span class="status-active">Up to Date</span>
+                <% end %>
+              </td>
+            </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <% else %>
+    <div class="empty-state">
+      <h4>No trucks available</h4>
+      <p>Contact your administrator to add trucks to your fleet.</p>
+    </div>
+    <% end %>
+  </div>
+
+  <!-- Active Delivery Alert -->
+  <% if @active_delivery %>
+  <div class="dashboard-section active-delivery-alert">
+    <div class="section-header">
+      <h3>🚛 Active Delivery</h3>
+    </div>
+
+    <div class="active-delivery-summary">
+      <div class="delivery-info">
+        <h4>You're currently on delivery #<%= @active_delivery.id %></h4>
+        <p><strong>Truck:</strong> <%= @active_delivery.truck&.display_name %></p>
+        <p><strong>Shipments:</strong> <%= @active_delivery.shipments.count %></p>
+        <p><strong>Status:</strong> <%= @active_delivery.status.gsub('_', ' ').capitalize %></p>
+      </div>
+      <div class="delivery-actions">
+        <%= link_to 'Continue Delivery', delivery_path(@active_delivery), class: 'primary-button' %>
+      </div>
+    </div>
+  </div>
+  <% end %>
 </div>
-<% end %>


### PR DESCRIPTION
## Description
There was too much overlap between the shipments index and the dashboard pages. This PR differentiates the dashboard page.

## Approach Taken
Update the customer and driver dashboards. Wrote new HTML and dedicated CSS rules.

## What Could Go Wrong?
Primarily a cosmetic change. Nothing major. All queries are robust.

## Remediation Strategy 
Depending on the size of the issue, either fix immediately, or rollback. Bias for the simplest remediation.
