### PR TITLE
XMDEV-468: Update render deploy script to clear cache

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -2,6 +2,7 @@
 # exit on error
 set -o errexit
 
+npm cache clean --force
 npm install
 bundle install
 bundle exec rails assets:precompile


### PR DESCRIPTION
## Description
Upon deploys to render, builds would fail due to an npm cache error. This updates the build script so that we clear the cache before starting the build.

## Approach Taken
Update the render build script.

## What Could Go Wrong?
Could crash the deployment. Deploy to sandbox first before deploying to prod.

## Remediation Strategy 
Fix until working in Sandbox, then deploy to prod.
