### PR TITLE
XMDEV-473: Fixes form submission on truck maintenance modal

### DIFF
--- a/app/javascript/controllers/create_maintenance_controller.js
+++ b/app/javascript/controllers/create_maintenance_controller.js
@@ -23,30 +23,28 @@ export default class extends Controller {
   }
 
   submitForm(event) {
-    event.preventDefault();
-  
-    // Get the truck ID
-    const truckId = this.truckIdInput.value;
-    
-    // Get form values
-    const form = event.target;
-    const formData = new FormData(form);
-    
-    // Create a new form for submission
+    // Allow both submit and click handlers; prefer submit events
+    if (event) event.preventDefault();
+
+    const formElement = this.form || event?.target || document.getElementById("maintenance-form");
+    const truckId = this.truckIdInput?.value || document.getElementById("modal-truck-id")?.value;
+    if (!truckId || !formElement) return;
+
+    const formData = new FormData(formElement);
+
     const submitForm = document.createElement("form");
     submitForm.method = "post";
-
     submitForm.action = `/trucks/${truckId}/create_form?truck_id=${truckId}`;
-    
-    // Add CSRF token
-    const csrfToken = document.querySelector("meta[name='csrf-token']").content;
-    const csrfInput = document.createElement("input");
-    csrfInput.type = "hidden";
-    csrfInput.name = "authenticity_token";
-    csrfInput.value = csrfToken;
-    submitForm.appendChild(csrfInput);
-    
-    // Add all form fields from the original form
+
+    const csrfTokenMeta = document.querySelector("meta[name='csrf-token']");
+    if (csrfTokenMeta?.content) {
+      const csrfInput = document.createElement("input");
+      csrfInput.type = "hidden";
+      csrfInput.name = "authenticity_token";
+      csrfInput.value = csrfTokenMeta.content;
+      submitForm.appendChild(csrfInput);
+    }
+
     for (const [key, value] of formData.entries()) {
       const input = document.createElement("input");
       input.type = "hidden";
@@ -54,8 +52,7 @@ export default class extends Controller {
       input.value = value;
       submitForm.appendChild(input);
     }
-    
-    // Submit the form
+
     document.body.appendChild(submitForm);
     submitForm.submit();
   }

--- a/app/views/forms/_maintenance_form.html.erb
+++ b/app/views/forms/_maintenance_form.html.erb
@@ -1,7 +1,7 @@
 <div class="modal-content">
   <h3>Maintenance Form</h3>
 
-  <form id="maintenance-form" method="post" data-action="create-maintenance#submitForm">
+  <form id="maintenance-form" method="post" data-action="submit->create-maintenance#submitForm">
     <p>Please complete the following maintenance information:</p>
 
     <div class="inspection-section">

--- a/features/admin_creating_a_truck.feature
+++ b/features/admin_creating_a_truck.feature
@@ -97,3 +97,4 @@ Feature: Admin Creating a Truck
     And I check "Tire pressure has been checked"
     And I fill in "Additional Notes" with "Initial maintenance completed"
     And I click "Confirm & Submit"
+    Then I should see a confirmation message

--- a/features/support/test_seeds.rb
+++ b/features/support/test_seeds.rb
@@ -176,7 +176,7 @@ module TestSeeds
       length: 13600,
       height: 2600,
       width: 2500,
-      vin: "TBDTBDTBDTBDTBDTB",
+      vin: "1HGCM82633A005432",
       license_plate: "DCE-1234",
       active: false
     )

--- a/features/trucking_company_managing_truck_maintenance.feature
+++ b/features/trucking_company_managing_truck_maintenance.feature
@@ -20,7 +20,6 @@ Feature: Trucking Company Managing Truck Maintenance (Driver from Dashboard)
     And I check "Tire pressure has been checked"
     And I fill in "Additional Notes" with "Completed maintenance from dashboard"
     And I click "Confirm & Submit"
-    And I wait
     Then I should see a confirmation message
 
 

--- a/features/trucking_company_managing_truck_maintenance.feature
+++ b/features/trucking_company_managing_truck_maintenance.feature
@@ -20,5 +20,7 @@ Feature: Trucking Company Managing Truck Maintenance (Driver from Dashboard)
     And I check "Tire pressure has been checked"
     And I fill in "Additional Notes" with "Completed maintenance from dashboard"
     And I click "Confirm & Submit"
+    And I wait
+    Then I should see a confirmation message
 
 


### PR DESCRIPTION
## Description
While working on some of our WDIO tests, we found that there was an issue with one of the stimulus controllers. Upon submission, the page wouldn't reload.

## Approach Taken
Refactored create maintenance controller so that the form submission triggers a page reload.

## What Could Go Wrong?
This is a deviation from the spec. It's a bug fix to make our stimulus controllers more robust. Things have already gone wrong!

## Remediation Strategy 
This is a bug fix. If this causes additional issues, lets fix them!