### PR TITLE
NO-JIRA: Update labels to add enhancement on update keyword

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
             LABELS+=("cucumber")
           fi
 
-          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'Add|add|create|Create'; then
+          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'Add|add|create|Create|Update|update'; then
             LABELS+=("enhancement")
           fi
 
@@ -111,7 +111,7 @@ jobs:
             LABELS+=("bug")
           fi
 
-          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'refactor|Refactor|Update|update'; then
+          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'refactor|Refactor'; then
             LABELS+=("refactor")
           fi
 


### PR DESCRIPTION
## Description
Dependabot PRs consistently add the `refactor` label to PRs. This is incorrect since those PRs are dependancy bumps. This PR updates our labelling workflow to add the `enhancement` label instead.

## Approach Taken
Move the keywords from once label category to another.

## What Could Go Wrong?
Nothing. Not a user facing change.

## Remediation Strategy 
NA